### PR TITLE
Add some endpoints for applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,219 +73,219 @@ following models:
 
 This table tracks progress through the redesign of the Juju client API:
 
-| Facade               | Facade Call                     | API Path                             |
-| :------------------- | :------------------------------ | :----------------------------------- |
-| Action               | Actions                         |                                      |
-| Action               | ApplicationsCharmsActions       |                                      |
-| Action               | Cancel                          |                                      |
-| Action               | EnqueueOperation                |                                      |
-| Action               | ListOperations                  |                                      |
-| Action               | Operations                      |                                      |
-| Action               | Run                             |                                      |
-| Action               | RunOnAllMachines                |                                      |
-| Action               | WatchActionsProgress            |                                      |
-| Admin                | Login                           |                                      |
-| Admin                | RedirectInfo                    |                                      |
-| AllModelWatcher      | Next                            |                                      |
-| AllModelWatcher      | Stop                            |                                      |
-| AllWatcher           | Next                            |                                      |
-| AllWatcher           | Stop                            |                                      |
-| Annotations          | Get                             |                                      |
-| Annotations          | Set                             |                                      |
-| Application          | AddRelation                     |                                      |
-| Application          | AddUnits                        |                                      |
-| Application          | ApplicationsInfo                |                                      |
-| Application          | CharmConfig                     |                                      |
-| Application          | CharmRelations                  |                                      |
-| Application          | Consume                         |                                      |
-| Application          | Deploy                          |                                      |
-| Application          | DeployFromRepository            |                                      |
-| Application          | DestroyApplication              |                                      |
-| Application          | DestroyConsumedApplications     |                                      |
-| Application          | DestroyRelation                 |                                      |
-| Application          | DestroyUnit                     |                                      |
-| Application          | Expose                          |                                      |
-| Application          | Get                             |                                      |
-| Application          | GetCharmURLOrigin               |                                      |
-| Application          | GetConfig                       |                                      |
-| Application          | GetConstraints                  |                                      |
-| Application          | Leader                          |                                      |
-| Application          | MergeBindings                   |                                      |
-| Application          | ResolveUnitErrors               |                                      |
-| Application          | ScaleApplications               |                                      |
-| Application          | SetCharm                        |                                      |
-| Application          | SetConfigs                      |                                      |
-| Application          | SetConstraints                  |                                      |
-| Application          | SetMetricCredentials            |                                      |
-| Application          | SetRelationsSuspended           |                                      |
-| Application          | Unexpose                        |                                      |
-| Application          | UnitsInfo                       |                                      |
-| Application          | UnsetApplicationsConfig         |                                      |
-| Application          | UpdateApplicationBase           |                                      |
-| ApplicationOffers    | ApplicationOffers               |                                      |
-| ApplicationOffers    | DestroyOffers                   |                                      |
-| ApplicationOffers    | FindApplicationOffers           |                                      |
-| ApplicationOffers    | GetConsumeDetails               |                                      |
-| ApplicationOffers    | ListApplicationOffers           |                                      |
-| ApplicationOffers    | ModifyOfferAccess               |                                      |
-| ApplicationOffers    | Offer                           |                                      |
-| ApplicationOffers    | RemoteApplicationInfo           |                                      |
-| Backup               | Create                          |                                      |
-| Block                | List                            |                                      |
-| Block                | SwitchBlockOff                  |                                      |
-| Block                | SwitchBlockOn                   |                                      |
-| Bundle               | ExportBundle                    |                                      |
-| Bundle               | GetChanges                      |                                      |
-| Bundle               | GetChangesMapArgs               |                                      |
-| Charms               | AddCharm                        |                                      |
-| Charms               | CharmInfo                       |                                      |
-| Charms               | CheckCharmPlacement             |                                      |
-| Charms               | GetDownloadInfos                |                                      |
-| Charms               | IsMetered                       |                                      |
-| Charms               | List                            |                                      |
-| Charms               | ListCharmResources              |                                      |
-| Charms               | ResolveCharms                   |                                      |
-| Client               | FindTools                       |                                      |
-| Client               | FullStatus                      |                                      |
-| Client               | StatusHistory                   |                                      |
-| Client               | WatchAll                        |                                      |
-| Cloud                | AddCloud                        | `POST /clouds`                       |
-| Cloud                | AddCredentials                  |                                      |
-| Cloud                | CheckCredentialsModels          |                                      |
-| Cloud                | Cloud                           | `GET /cloud/{name}`                  |
-| Cloud                | CloudInfo                       | `GET /cloud/{name}`                  |
-| Cloud                | Clouds                          | `GET /clouds/supported`              |
-| Cloud                | Credential                      |                                      |
-| Cloud                | CredentialContents              |                                      |
-| Cloud                | InstanceTypes                   |                                      |
-| Cloud                | ListCloudInfo                   | `GET /clouds`                        |
-| Cloud                | ModifyCloudAccess               | `PATCH /cloud/{name}/access`         |
-| Cloud                | RemoveClouds                    | `DELETE /cloud/{name}`               |
-| Cloud                | RevokeCredentialsCheckModels    |                                      |
-| Cloud                | UpdateCloud                     |                                      |
-| Cloud                | UpdateCredentialsCheckModels    |                                      |
-| Cloud                | UserCredentials                 |                                      |
-| Controller           | AllModels                       |                                      |
-| Controller           | CloudSpec                       |                                      |
-| Controller           | ConfigSet                       |                                      |
-| Controller           | ControllerAPIInfoForModels      |                                      |
-| Controller           | ControllerConfig                |                                      |
-| Controller           | ControllerVersion               |                                      |
-| Controller           | DashboardConnectionInfo         |                                      |
-| Controller           | DestroyController               |                                      |
-| Controller           | GetCloudSpec                    |                                      |
-| Controller           | GetControllerAccess             |                                      |
-| Controller           | HostedModelConfigs              |                                      |
-| Controller           | IdentityProviderURL             |                                      |
-| Controller           | InitiateMigration               |                                      |
-| Controller           | ListBlockedModels               |                                      |
-| Controller           | ModelConfig                     |                                      |
-| Controller           | ModelStatus                     |                                      |
-| Controller           | ModifyControllerAccess          |                                      |
-| Controller           | MongoVersion                    |                                      |
-| Controller           | RemoveBlocks                    |                                      |
-| Controller           | WatchAllModelSummaries          |                                      |
-| Controller           | WatchAllModels                  |                                      |
-| Controller           | WatchCloudSpecsChanges          |                                      |
-| Controller           | WatchModelSummaries             |                                      |
-| CredentialManager    | InvalidateModelCredential       |                                      |
-| FirewallRules        | ListFirewallRules               |                                      |
-| FirewallRules        | SetFirewallRules                |                                      |
-| HighAvailability     | EnableHA                        |                                      |
-| ImageMetaDataManager | Delete                          |                                      |
-| ImageMetaDataManager | List                            |                                      |
-| ImageMetaDataManager | Save                            |                                      |
-| KeyManager           | AddKeys                         |                                      |
-| KeyManager           | DeleteKeys                      |                                      |
-| KeyManager           | ImportKeys                      |                                      |
-| KeyManager           | ListKeys                        |                                      |
-| MachineManager       | AddMachines                     |                                      |
-| MachineManager       | DestroyMachineWithParams        |                                      |
-| MachineManager       | GetUpgradeSeriesMessages        |                                      |
-| MachineManager       | InstanceTypes                   |                                      |
-| MachineManager       | ProvisioningScript              |                                      |
-| MachineManager       | RetryProvisioning               |                                      |
-| MachineManager       | UpgradeSeriesComplete           |                                      |
-| MachineManager       | UpgradeSeriesPrepare            |                                      |
-| MachineManager       | UpgradeSeriesValidate           |                                      |
-| MachineManager       | WatchUpgradeSeriesNotifications |                                      |
-| MetricsDebug         | GetMetrics                      |                                      |
-| MetricsDebug         | SetMeterStatus                  |                                      |
-| ModelConfig          | GetModelConstraints             |                                      |
-| ModelConfig          | ModelGet                        |                                      |
-| ModelConfig          | ModelSet                        |                                      |
-| ModelConfig          | ModelUnset                      |                                      |
-| ModelConfig          | SLALevel                        |                                      |
-| ModelConfig          | Sequences                       |                                      |
-| ModelConfig          | SetModelConstraints             |                                      |
-| ModelConfig          | SetSLALevel                     |                                      |
-| ModelGeneration      | AbortBranch                     |                                      |
-| ModelGeneration      | AddBranch                       |                                      |
-| ModelGeneration      | BranchInfo                      |                                      |
-| ModelGeneration      | CommitBranch                    |                                      |
-| ModelGeneration      | HasActiveBranch                 |                                      |
-| ModelGeneration      | ListCommits                     |                                      |
-| ModelGeneration      | ShowCommit                      |                                      |
-| ModelGeneration      | TrackBranch                     |                                      |
-| ModelManager         | ChangeModelCredential           | `PATCH /model/{name}/credential`     |
-| ModelManager         | CreateModel                     | `POST /models`                       |
-| ModelManager         | DestroyModels                   | `DELETE /model/{name}`               |
-| ModelManager         | DumpModels                      | `GET /models?detailed=true&all=true` |
-| ModelManager         | DumpModelsDB                    | N/A                                  |
-| ModelManager         | ListModelSummaries              | `GET /models?detailed=true`          |
-| ModelManager         | ListModels                      | `GET /models`                        |
-| ModelManager         | ModelDefaultsForClouds          | `GET /models/defaults`               |
-| ModelManager         | ModelInfo                       | `GET /model/{name}`                  |
-| ModelManager         | ModelStatus                     | `GET /model/{name}/status`           |
-| ModelManager         | ModifyModelAccess               | `PATCH /model/{name}/access`         |
-| ModelManager         | SetModelDefaults                | `PATCH /models/defaults`             |
-| ModelManager         | UnsetModelDefaults              | `PATCH /models/defaults`             |
-| ModelUpgrader        | AbortModelUpgrade               |                                      |
-| ModelUpgrader        | UpgradeModel                    |                                      |
-| Payloads             | List                            |                                      |
-| Pinger               | Ping                            |                                      |
-| Pinger               | Stop                            |                                      |
-| Resources            | AddPendingResources             |                                      |
-| Resources            | ListResources                   |                                      |
-| SSHClient            | AllAddresses                    |                                      |
-| SSHClient            | ModelCredentialForSSH           |                                      |
-| SSHClient            | PrivateAddress                  |                                      |
-| SSHClient            | Proxy                           |                                      |
-| SSHClient            | PublicAddress                   |                                      |
-| SSHClient            | PublicKeys                      |                                      |
-| SecretBackends       | AddSecretBackends               |                                      |
-| SecretBackends       | ListSecretBackends              |                                      |
-| SecretBackends       | RemoveSecretBackends            |                                      |
-| SecretBackends       | UpdateSecretBackends            |                                      |
-| Secrets              | ListSecrets                     |                                      |
-| Spaces               | CreateSpaces                    |                                      |
-| Spaces               | ListSpaces                      |                                      |
-| Spaces               | MoveSubnets                     |                                      |
-| Spaces               | ReloadSpaces                    |                                      |
-| Spaces               | RemoveSpace                     |                                      |
-| Spaces               | RenameSpace                     |                                      |
-| Spaces               | ShowSpace                       |                                      |
-| Storage              | AddToUnit                       |                                      |
-| Storage              | Attach                          |                                      |
-| Storage              | CreatePool                      |                                      |
-| Storage              | DetachStorage                   |                                      |
-| Storage              | Import                          |                                      |
-| Storage              | ListFilesystems                 |                                      |
-| Storage              | ListPools                       |                                      |
-| Storage              | ListStorageDetails              |                                      |
-| Storage              | ListVolumes                     |                                      |
-| Storage              | Remove                          |                                      |
-| Storage              | RemovePool                      |                                      |
-| Storage              | StorageDetails                  |                                      |
-| Storage              | UpdatePool                      |                                      |
-| Subnets              | AllZones                        |                                      |
-| Subnets              | ListSubnets                     |                                      |
-| Subnets              | SubnetsByCIDR                   |                                      |
-| UserManager          | AddUser                         |                                      |
-| UserManager          | DisableUser                     |                                      |
-| UserManager          | EnableUser                      |                                      |
-| UserManager          | ModelUserInfo                   |                                      |
-| UserManager          | RemoveUser                      |                                      |
-| UserManager          | ResetPassword                   |                                      |
-| UserManager          | SetPassword                     |                                      |
-| UserManager          | UserInfo                        |                                      |
+| Facade               | Facade Call                     | API Path                                                         |
+| :------------------- | :------------------------------ |:-----------------------------------------------------------------|
+| Action               | Actions                         |                                                                  |
+| Action               | ApplicationsCharmsActions       |                                                                  |
+| Action               | Cancel                          |                                                                  |
+| Action               | EnqueueOperation                |                                                                  |
+| Action               | ListOperations                  |                                                                  |
+| Action               | Operations                      |                                                                  |
+| Action               | Run                             |                                                                  |
+| Action               | RunOnAllMachines                |                                                                  |
+| Action               | WatchActionsProgress            |                                                                  |
+| Admin                | Login                           |                                                                  |
+| Admin                | RedirectInfo                    |                                                                  |
+| AllModelWatcher      | Next                            |                                                                  |
+| AllModelWatcher      | Stop                            |                                                                  |
+| AllWatcher           | Next                            |                                                                  |
+| AllWatcher           | Stop                            |                                                                  |
+| Annotations          | Get                             |                                                                  |
+| Annotations          | Set                             |                                                                  |
+| Application          | AddRelation                     | `POST /application/relate`                                       |
+| Application          | AddUnits                        |                                                                  |
+| Application          | ApplicationsInfo                | `GET /application/{name}`                                        |
+| Application          | CharmConfig                     |                                                                  |
+| Application          | CharmRelations                  |                                                                  |
+| Application          | Consume                         |                                                                  |
+| Application          | Deploy                          |                                                                  |
+| Application          | DeployFromRepository            | `POST /application/{name}?force=false&dry-run=false&trust=false` |
+| Application          | DestroyApplication              | `DELETE /application/{name}`                                     |
+| Application          | DestroyConsumedApplications     |                                                                  |
+| Application          | DestroyRelation                 |                                                                  |
+| Application          | DestroyUnit                     |                                                                  |
+| Application          | Expose                          |                                                                  |
+| Application          | Get                             |                                                                  |
+| Application          | GetCharmURLOrigin               |                                                                  |
+| Application          | GetConfig                       |                                                                  |
+| Application          | GetConstraints                  |                                                                  |
+| Application          | Leader                          |                                                                  |
+| Application          | MergeBindings                   |                                                                  |
+| Application          | ResolveUnitErrors               |                                                                  |
+| Application          | ScaleApplications               |                                                                  |
+| Application          | SetCharm                        | `PATCH /application/{name}`                                      |
+| Application          | SetConfigs                      |                                                                  |
+| Application          | SetConstraints                  |                                                                  |
+| Application          | SetMetricCredentials            |                                                                  |
+| Application          | SetRelationsSuspended           |                                                                  |
+| Application          | Unexpose                        |                                                                  |
+| Application          | UnitsInfo                       |                                                                  |
+| Application          | UnsetApplicationsConfig         |                                                                  |
+| Application          | UpdateApplicationBase           |                                                                  |
+| ApplicationOffers    | ApplicationOffers               |                                                                  |
+| ApplicationOffers    | DestroyOffers                   |                                                                  |
+| ApplicationOffers    | FindApplicationOffers           |                                                                  |
+| ApplicationOffers    | GetConsumeDetails               |                                                                  |
+| ApplicationOffers    | ListApplicationOffers           |                                                                  |
+| ApplicationOffers    | ModifyOfferAccess               |                                                                  |
+| ApplicationOffers    | Offer                           |                                                                  |
+| ApplicationOffers    | RemoteApplicationInfo           |                                                                  |
+| Backup               | Create                          |                                                                  |
+| Block                | List                            |                                                                  |
+| Block                | SwitchBlockOff                  |                                                                  |
+| Block                | SwitchBlockOn                   |                                                                  |
+| Bundle               | ExportBundle                    |                                                                  |
+| Bundle               | GetChanges                      |                                                                  |
+| Bundle               | GetChangesMapArgs               |                                                                  |
+| Charms               | AddCharm                        |                                                                  |
+| Charms               | CharmInfo                       |                                                                  |
+| Charms               | CheckCharmPlacement             |                                                                  |
+| Charms               | GetDownloadInfos                |                                                                  |
+| Charms               | IsMetered                       |                                                                  |
+| Charms               | List                            |                                                                  |
+| Charms               | ListCharmResources              |                                                                  |
+| Charms               | ResolveCharms                   |                                                                  |
+| Client               | FindTools                       |                                                                  |
+| Client               | FullStatus                      |                                                                  |
+| Client               | StatusHistory                   |                                                                  |
+| Client               | WatchAll                        |                                                                  |
+| Cloud                | AddCloud                        | `POST /clouds`                                                   |
+| Cloud                | AddCredentials                  |                                                                  |
+| Cloud                | CheckCredentialsModels          |                                                                  |
+| Cloud                | Cloud                           | `GET /cloud/{name}`                                              |
+| Cloud                | CloudInfo                       | `GET /cloud/{name}`                                              |
+| Cloud                | Clouds                          | `GET /clouds/supported`                                          |
+| Cloud                | Credential                      |                                                                  |
+| Cloud                | CredentialContents              |                                                                  |
+| Cloud                | InstanceTypes                   |                                                                  |
+| Cloud                | ListCloudInfo                   | `GET /clouds`                                                    |
+| Cloud                | ModifyCloudAccess               | `PATCH /cloud/{name}/access`                                     |
+| Cloud                | RemoveClouds                    | `DELETE /cloud/{name}`                                           |
+| Cloud                | RevokeCredentialsCheckModels    |                                                                  |
+| Cloud                | UpdateCloud                     |                                                                  |
+| Cloud                | UpdateCredentialsCheckModels    |                                                                  |
+| Cloud                | UserCredentials                 |                                                                  |
+| Controller           | AllModels                       |                                                                  |
+| Controller           | CloudSpec                       |                                                                  |
+| Controller           | ConfigSet                       |                                                                  |
+| Controller           | ControllerAPIInfoForModels      |                                                                  |
+| Controller           | ControllerConfig                |                                                                  |
+| Controller           | ControllerVersion               |                                                                  |
+| Controller           | DashboardConnectionInfo         |                                                                  |
+| Controller           | DestroyController               |                                                                  |
+| Controller           | GetCloudSpec                    |                                                                  |
+| Controller           | GetControllerAccess             |                                                                  |
+| Controller           | HostedModelConfigs              |                                                                  |
+| Controller           | IdentityProviderURL             |                                                                  |
+| Controller           | InitiateMigration               |                                                                  |
+| Controller           | ListBlockedModels               |                                                                  |
+| Controller           | ModelConfig                     |                                                                  |
+| Controller           | ModelStatus                     |                                                                  |
+| Controller           | ModifyControllerAccess          |                                                                  |
+| Controller           | MongoVersion                    |                                                                  |
+| Controller           | RemoveBlocks                    |                                                                  |
+| Controller           | WatchAllModelSummaries          |                                                                  |
+| Controller           | WatchAllModels                  |                                                                  |
+| Controller           | WatchCloudSpecsChanges          |                                                                  |
+| Controller           | WatchModelSummaries             |                                                                  |
+| CredentialManager    | InvalidateModelCredential       |                                                                  |
+| FirewallRules        | ListFirewallRules               |                                                                  |
+| FirewallRules        | SetFirewallRules                |                                                                  |
+| HighAvailability     | EnableHA                        |                                                                  |
+| ImageMetaDataManager | Delete                          |                                                                  |
+| ImageMetaDataManager | List                            |                                                                  |
+| ImageMetaDataManager | Save                            |                                                                  |
+| KeyManager           | AddKeys                         |                                                                  |
+| KeyManager           | DeleteKeys                      |                                                                  |
+| KeyManager           | ImportKeys                      |                                                                  |
+| KeyManager           | ListKeys                        |                                                                  |
+| MachineManager       | AddMachines                     |                                                                  |
+| MachineManager       | DestroyMachineWithParams        |                                                                  |
+| MachineManager       | GetUpgradeSeriesMessages        |                                                                  |
+| MachineManager       | InstanceTypes                   |                                                                  |
+| MachineManager       | ProvisioningScript              |                                                                  |
+| MachineManager       | RetryProvisioning               |                                                                  |
+| MachineManager       | UpgradeSeriesComplete           |                                                                  |
+| MachineManager       | UpgradeSeriesPrepare            |                                                                  |
+| MachineManager       | UpgradeSeriesValidate           |                                                                  |
+| MachineManager       | WatchUpgradeSeriesNotifications |                                                                  |
+| MetricsDebug         | GetMetrics                      |                                                                  |
+| MetricsDebug         | SetMeterStatus                  |                                                                  |
+| ModelConfig          | GetModelConstraints             |                                                                  |
+| ModelConfig          | ModelGet                        |                                                                  |
+| ModelConfig          | ModelSet                        |                                                                  |
+| ModelConfig          | ModelUnset                      |                                                                  |
+| ModelConfig          | SLALevel                        |                                                                  |
+| ModelConfig          | Sequences                       |                                                                  |
+| ModelConfig          | SetModelConstraints             |                                                                  |
+| ModelConfig          | SetSLALevel                     |                                                                  |
+| ModelGeneration      | AbortBranch                     |                                                                  |
+| ModelGeneration      | AddBranch                       |                                                                  |
+| ModelGeneration      | BranchInfo                      |                                                                  |
+| ModelGeneration      | CommitBranch                    |                                                                  |
+| ModelGeneration      | HasActiveBranch                 |                                                                  |
+| ModelGeneration      | ListCommits                     |                                                                  |
+| ModelGeneration      | ShowCommit                      |                                                                  |
+| ModelGeneration      | TrackBranch                     |                                                                  |
+| ModelManager         | ChangeModelCredential           | `PATCH /model/{name}/credential`                                 |
+| ModelManager         | CreateModel                     | `POST /models`                                                   |
+| ModelManager         | DestroyModels                   | `DELETE /model/{name}`                                           |
+| ModelManager         | DumpModels                      | `GET /models?detailed=true&all=true`                             |
+| ModelManager         | DumpModelsDB                    | N/A                                                              |
+| ModelManager         | ListModelSummaries              | `GET /models?detailed=true`                                      |
+| ModelManager         | ListModels                      | `GET /models`                                                    |
+| ModelManager         | ModelDefaultsForClouds          | `GET /models/defaults`                                           |
+| ModelManager         | ModelInfo                       | `GET /model/{name}`                                              |
+| ModelManager         | ModelStatus                     | `GET /model/{name}/status`                                       |
+| ModelManager         | ModifyModelAccess               | `PATCH /model/{name}/access`                                     |
+| ModelManager         | SetModelDefaults                | `PATCH /models/defaults`                                         |
+| ModelManager         | UnsetModelDefaults              | `PATCH /models/defaults`                                         |
+| ModelUpgrader        | AbortModelUpgrade               |                                                                  |
+| ModelUpgrader        | UpgradeModel                    |                                                                  |
+| Payloads             | List                            |                                                                  |
+| Pinger               | Ping                            |                                                                  |
+| Pinger               | Stop                            |                                                                  |
+| Resources            | AddPendingResources             |                                                                  |
+| Resources            | ListResources                   |                                                                  |
+| SSHClient            | AllAddresses                    |                                                                  |
+| SSHClient            | ModelCredentialForSSH           |                                                                  |
+| SSHClient            | PrivateAddress                  |                                                                  |
+| SSHClient            | Proxy                           |                                                                  |
+| SSHClient            | PublicAddress                   |                                                                  |
+| SSHClient            | PublicKeys                      |                                                                  |
+| SecretBackends       | AddSecretBackends               |                                                                  |
+| SecretBackends       | ListSecretBackends              |                                                                  |
+| SecretBackends       | RemoveSecretBackends            |                                                                  |
+| SecretBackends       | UpdateSecretBackends            |                                                                  |
+| Secrets              | ListSecrets                     |                                                                  |
+| Spaces               | CreateSpaces                    |                                                                  |
+| Spaces               | ListSpaces                      |                                                                  |
+| Spaces               | MoveSubnets                     |                                                                  |
+| Spaces               | ReloadSpaces                    |                                                                  |
+| Spaces               | RemoveSpace                     |                                                                  |
+| Spaces               | RenameSpace                     |                                                                  |
+| Spaces               | ShowSpace                       |                                                                  |
+| Storage              | AddToUnit                       |                                                                  |
+| Storage              | Attach                          |                                                                  |
+| Storage              | CreatePool                      |                                                                  |
+| Storage              | DetachStorage                   |                                                                  |
+| Storage              | Import                          |                                                                  |
+| Storage              | ListFilesystems                 |                                                                  |
+| Storage              | ListPools                       |                                                                  |
+| Storage              | ListStorageDetails              |                                                                  |
+| Storage              | ListVolumes                     |                                                                  |
+| Storage              | Remove                          |                                                                  |
+| Storage              | RemovePool                      |                                                                  |
+| Storage              | StorageDetails                  |                                                                  |
+| Storage              | UpdatePool                      |                                                                  |
+| Subnets              | AllZones                        |                                                                  |
+| Subnets              | ListSubnets                     |                                                                  |
+| Subnets              | SubnetsByCIDR                   |                                                                  |
+| UserManager          | AddUser                         |                                                                  |
+| UserManager          | DisableUser                     |                                                                  |
+| UserManager          | EnableUser                      |                                                                  |
+| UserManager          | ModelUserInfo                   |                                                                  |
+| UserManager          | RemoveUser                      |                                                                  |
+| UserManager          | ResetPassword                   |                                                                  |
+| UserManager          | SetPassword                     |                                                                  |
+| UserManager          | UserInfo                        |                                                                  |

--- a/README.md
+++ b/README.md
@@ -51,219 +51,219 @@ go run schemagen.go -admin-facades -facade-group client ./schemas/client-schemas
 
 This table tracks progress through the redesign of the Juju client API:
 
-| Facade               | Facade Call                     | API Path                                                                                     |
-| :------------------- | :------------------------------ |:---------------------------------------------------------------------------------------------|
-| Action               | Actions                         |                                                                                              |
-| Action               | ApplicationsCharmsActions       |                                                                                              |
-| Action               | Cancel                          |                                                                                              |
-| Action               | EnqueueOperation                |                                                                                              |
-| Action               | ListOperations                  |                                                                                              |
-| Action               | Operations                      |                                                                                              |
-| Action               | Run                             |                                                                                              |
-| Action               | RunOnAllMachines                |                                                                                              |
-| Action               | WatchActionsProgress            |                                                                                              |
-| Admin                | Login                           |                                                                                              |
-| Admin                | RedirectInfo                    |                                                                                              |
-| AllModelWatcher      | Next                            |                                                                                              |
-| AllModelWatcher      | Stop                            |                                                                                              |
-| AllWatcher           | Next                            |                                                                                              |
-| AllWatcher           | Stop                            |                                                                                              |
-| Annotations          | Get                             |                                                                                              |
-| Annotations          | Set                             |                                                                                              |
-| Application          | AddRelation                     | `POST /integrate`                                                                            |
-| Application          | AddUnits                        |                                                                                              |
-| Application          | ApplicationsInfo                | `GET /model/{model}/application/{application}`                                                |
-| Application          | CharmConfig                     |                                                                                              |
-| Application          | CharmRelations                  |                                                                                              |
-| Application          | Consume                         |                                                                                              |
-| Application          | Deploy                          |                                                                                              |
-| Application          | DeployFromRepository            | `POST /model/{model}/application/{application}/deploy&dry-run=false&trust=false` |
-| Application          | DestroyApplication              | `DELETE /model/{model}/application/{application}`                                            |
-| Application          | DestroyConsumedApplications     |                                                                                              |
-| Application          | DestroyRelation                 |                                                                                              |
-| Application          | DestroyUnit                     |                                                                                              |
-| Application          | Expose                          |                                                                                              |
-| Application          | Get                             |                                                                                              |
-| Application          | GetCharmURLOrigin               |                                                                                              |
-| Application          | GetConfig                       |                                                                                              |
-| Application          | GetConstraints                  |                                                                                              |
-| Application          | Leader                          |                                                                                              |
-| Application          | MergeBindings                   |                                                                                              |
-| Application          | ResolveUnitErrors               |                                                                                              |
-| Application          | ScaleApplications               |                                                                                              |
-| Application          | SetCharm                        | `PATCH /model/{model}/application/{application}/refresh`           |
-| Application          | SetConfigs                      |                                                                                              |
-| Application          | SetConstraints                  |                                                                                              |
-| Application          | SetMetricCredentials            |                                                                                              |
-| Application          | SetRelationsSuspended           |                                                                                              |
-| Application          | Unexpose                        |                                                                                              |
-| Application          | UnitsInfo                       |                                                                                              |
-| Application          | UnsetApplicationsConfig         |                                                                                              |
-| Application          | UpdateApplicationBase           |                                                                                              |
-| ApplicationOffers    | ApplicationOffers               |                                                                                              |
-| ApplicationOffers    | DestroyOffers                   |                                                                                              |
-| ApplicationOffers    | FindApplicationOffers           |                                                                                              |
-| ApplicationOffers    | GetConsumeDetails               |                                                                                              |
-| ApplicationOffers    | ListApplicationOffers           |                                                                                              |
-| ApplicationOffers    | ModifyOfferAccess               |                                                                                              |
-| ApplicationOffers    | Offer                           |                                                                                              |
-| ApplicationOffers    | RemoteApplicationInfo           |                                                                                              |
-| Backup               | Create                          |                                                                                              |
-| Block                | List                            |                                                                                              |
-| Block                | SwitchBlockOff                  |                                                                                              |
-| Block                | SwitchBlockOn                   |                                                                                              |
-| Bundle               | ExportBundle                    |                                                                                              |
-| Bundle               | GetChanges                      |                                                                                              |
-| Bundle               | GetChangesMapArgs               |                                                                                              |
-| Charms               | AddCharm                        |                                                                                              |
-| Charms               | CharmInfo                       |                                                                                              |
-| Charms               | CheckCharmPlacement             |                                                                                              |
-| Charms               | GetDownloadInfos                |                                                                                              |
-| Charms               | IsMetered                       |                                                                                              |
-| Charms               | List                            |                                                                                              |
-| Charms               | ListCharmResources              |                                                                                              |
-| Charms               | ResolveCharms                   |                                                                                              |
-| Client               | FindTools                       |                                                                                              |
-| Client               | FullStatus                      |                                                                                              |
-| Client               | StatusHistory                   |                                                                                              |
-| Client               | WatchAll                        |                                                                                              |
-| Cloud                | AddCloud                        | `POST /clouds`                                                                               |
-| Cloud                | AddCredentials                  |                                                                                              |
-| Cloud                | CheckCredentialsModels          |                                                                                              |
-| Cloud                | Cloud                           | `GET /cloud/{cloud}`                                                                         |
-| Cloud                | CloudInfo                       | `GET /cloud/{cloud}`                                                                         |
-| Cloud                | Clouds                          | `GET /clouds/supported`                                                                      |
-| Cloud                | Credential                      |                                                                                              |
-| Cloud                | CredentialContents              |                                                                                              |
-| Cloud                | InstanceTypes                   |                                                                                              |
-| Cloud                | ListCloudInfo                   | `GET /clouds`                                                                                |
-| Cloud                | ModifyCloudAccess               | `PATCH /cloud/{cloud}/access`                                                                |
-| Cloud                | RemoveClouds                    | `DELETE /cloud/{cloud}`                                                                      |
-| Cloud                | RevokeCredentialsCheckModels    |                                                                                              |
-| Cloud                | UpdateCloud                     |                                                                                              |
-| Cloud                | UpdateCredentialsCheckModels    |                                                                                              |
-| Cloud                | UserCredentials                 |                                                                                              |
-| Controller           | AllModels                       |                                                                                              |
-| Controller           | CloudSpec                       |                                                                                              |
-| Controller           | ConfigSet                       |                                                                                              |
-| Controller           | ControllerAPIInfoForModels      |                                                                                              |
-| Controller           | ControllerConfig                |                                                                                              |
-| Controller           | ControllerVersion               |                                                                                              |
-| Controller           | DashboardConnectionInfo         |                                                                                              |
-| Controller           | DestroyController               |                                                                                              |
-| Controller           | GetCloudSpec                    |                                                                                              |
-| Controller           | GetControllerAccess             |                                                                                              |
-| Controller           | HostedModelConfigs              |                                                                                              |
-| Controller           | IdentityProviderURL             |                                                                                              |
-| Controller           | InitiateMigration               |                                                                                              |
-| Controller           | ListBlockedModels               |                                                                                              |
-| Controller           | ModelConfig                     |                                                                                              |
-| Controller           | ModelStatus                     |                                                                                              |
-| Controller           | ModifyControllerAccess          |                                                                                              |
-| Controller           | MongoVersion                    |                                                                                              |
-| Controller           | RemoveBlocks                    |                                                                                              |
-| Controller           | WatchAllModelSummaries          |                                                                                              |
-| Controller           | WatchAllModels                  |                                                                                              |
-| Controller           | WatchCloudSpecsChanges          |                                                                                              |
-| Controller           | WatchModelSummaries             |                                                                                              |
-| CredentialManager    | InvalidateModelCredential       |                                                                                              |
-| FirewallRules        | ListFirewallRules               |                                                                                              |
-| FirewallRules        | SetFirewallRules                |                                                                                              |
-| HighAvailability     | EnableHA                        |                                                                                              |
-| ImageMetaDataManager | Delete                          |                                                                                              |
-| ImageMetaDataManager | List                            |                                                                                              |
-| ImageMetaDataManager | Save                            |                                                                                              |
-| KeyManager           | AddKeys                         |                                                                                              |
-| KeyManager           | DeleteKeys                      |                                                                                              |
-| KeyManager           | ImportKeys                      |                                                                                              |
-| KeyManager           | ListKeys                        |                                                                                              |
-| MachineManager       | AddMachines                     |                                                                                              |
-| MachineManager       | DestroyMachineWithParams        |                                                                                              |
-| MachineManager       | GetUpgradeSeriesMessages        |                                                                                              |
-| MachineManager       | InstanceTypes                   |                                                                                              |
-| MachineManager       | ProvisioningScript              |                                                                                              |
-| MachineManager       | RetryProvisioning               |                                                                                              |
-| MachineManager       | UpgradeSeriesComplete           |                                                                                              |
-| MachineManager       | UpgradeSeriesPrepare            |                                                                                              |
-| MachineManager       | UpgradeSeriesValidate           |                                                                                              |
-| MachineManager       | WatchUpgradeSeriesNotifications |                                                                                              |
-| MetricsDebug         | GetMetrics                      |                                                                                              |
-| MetricsDebug         | SetMeterStatus                  |                                                                                              |
-| ModelConfig          | GetModelConstraints             |                                                                                              |
-| ModelConfig          | ModelGet                        |                                                                                              |
-| ModelConfig          | ModelSet                        |                                                                                              |
-| ModelConfig          | ModelUnset                      |                                                                                              |
-| ModelConfig          | SLALevel                        |                                                                                              |
-| ModelConfig          | Sequences                       |                                                                                              |
-| ModelConfig          | SetModelConstraints             |                                                                                              |
-| ModelConfig          | SetSLALevel                     |                                                                                              |
-| ModelGeneration      | AbortBranch                     |                                                                                              |
-| ModelGeneration      | AddBranch                       |                                                                                              |
-| ModelGeneration      | BranchInfo                      |                                                                                              |
-| ModelGeneration      | CommitBranch                    |                                                                                              |
-| ModelGeneration      | HasActiveBranch                 |                                                                                              |
-| ModelGeneration      | ListCommits                     |                                                                                              |
-| ModelGeneration      | ShowCommit                      |                                                                                              |
-| ModelGeneration      | TrackBranch                     |                                                                                              |
-| ModelManager         | ChangeModelCredential           | `PATCH /model/{model}/credential`                                                            |
-| ModelManager         | CreateModel                     | `POST /models`                                                                               |
-| ModelManager         | DestroyModels                   | `DELETE /model/{model}`                                                                      |
-| ModelManager         | DumpModels                      | `GET /models?detailed=true&all=true`                                                         |
-| ModelManager         | DumpModelsDB                    | N/A                                                                                          |
-| ModelManager         | ListModelSummaries              | `GET /models?detailed=true`                                                                  |
-| ModelManager         | ListModels                      | `GET /models`                                                                                |
-| ModelManager         | ModelDefaultsForClouds          | `GET /models/defaults`                                                                       |
-| ModelManager         | ModelInfo                       | `GET /model/{model}`                                                                         |
-| ModelManager         | ModelStatus                     | `GET /model/{model}/status`                                                                  |
-| ModelManager         | ModifyModelAccess               | `PATCH /model/{model}/access`                                                                |
-| ModelManager         | SetModelDefaults                | `PATCH /models/defaults`                                                                     |
-| ModelManager         | UnsetModelDefaults              | `PATCH /models/defaults`                                                                     |
-| ModelUpgrader        | AbortModelUpgrade               |                                                                                              |
-| ModelUpgrader        | UpgradeModel                    |                                                                                              |
-| Payloads             | List                            |                                                                                              |
-| Pinger               | Ping                            |                                                                                              |
-| Pinger               | Stop                            |                                                                                              |
-| Resources            | AddPendingResources             |                                                                                              |
-| Resources            | ListResources                   |                                                                                              |
-| SSHClient            | AllAddresses                    |                                                                                              |
-| SSHClient            | ModelCredentialForSSH           |                                                                                              |
-| SSHClient            | PrivateAddress                  |                                                                                              |
-| SSHClient            | Proxy                           |                                                                                              |
-| SSHClient            | PublicAddress                   |                                                                                              |
-| SSHClient            | PublicKeys                      |                                                                                              |
-| SecretBackends       | AddSecretBackends               |                                                                                              |
-| SecretBackends       | ListSecretBackends              |                                                                                              |
-| SecretBackends       | RemoveSecretBackends            |                                                                                              |
-| SecretBackends       | UpdateSecretBackends            |                                                                                              |
-| Secrets              | ListSecrets                     |                                                                                              |
-| Spaces               | CreateSpaces                    |                                                                                              |
-| Spaces               | ListSpaces                      |                                                                                              |
-| Spaces               | MoveSubnets                     |                                                                                              |
-| Spaces               | ReloadSpaces                    |                                                                                              |
-| Spaces               | RemoveSpace                     |                                                                                              |
-| Spaces               | RenameSpace                     |                                                                                              |
-| Spaces               | ShowSpace                       |                                                                                              |
-| Storage              | AddToUnit                       |                                                                                              |
-| Storage              | Attach                          |                                                                                              |
-| Storage              | CreatePool                      |                                                                                              |
-| Storage              | DetachStorage                   |                                                                                              |
-| Storage              | Import                          |                                                                                              |
-| Storage              | ListFilesystems                 |                                                                                              |
-| Storage              | ListPools                       |                                                                                              |
-| Storage              | ListStorageDetails              |                                                                                              |
-| Storage              | ListVolumes                     |                                                                                              |
-| Storage              | Remove                          |                                                                                              |
-| Storage              | RemovePool                      |                                                                                              |
-| Storage              | StorageDetails                  |                                                                                              |
-| Storage              | UpdatePool                      |                                                                                              |
-| Subnets              | AllZones                        |                                                                                              |
-| Subnets              | ListSubnets                     |                                                                                              |
-| Subnets              | SubnetsByCIDR                   |                                                                                              |
-| UserManager          | AddUser                         | `POST /users`                                                                                |
-| UserManager          | DisableUser                     | `PATCH /user/{user}`                                                                         |
-| UserManager          | EnableUser                      | `PATCH /user/{user}`                                                                         |
-| UserManager          | ModelUserInfo                   | `GET /models?user={user}`                                                                    |
-| UserManager          | RemoveUser                      | `DELETE /user/{user}`                                                                        |
-| UserManager          | ResetPassword                   | `PATCH /user/{user}`                                                                         |
-| UserManager          | SetPassword                     | `PATCH /user/{user}`                                                                         |
-| UserManager          | UserInfo                        | `GET /user/{user}`                                                                           |
+| Facade               | Facade Call                     | API Path                                                 |
+| :------------------- | :------------------------------ |:---------------------------------------------------------|
+| Action               | Actions                         |                                                          |
+| Action               | ApplicationsCharmsActions       |                                                          |
+| Action               | Cancel                          |                                                          |
+| Action               | EnqueueOperation                |                                                          |
+| Action               | ListOperations                  |                                                          |
+| Action               | Operations                      |                                                          |
+| Action               | Run                             |                                                          |
+| Action               | RunOnAllMachines                |                                                          |
+| Action               | WatchActionsProgress            |                                                          |
+| Admin                | Login                           |                                                          |
+| Admin                | RedirectInfo                    |                                                          |
+| AllModelWatcher      | Next                            |                                                          |
+| AllModelWatcher      | Stop                            |                                                          |
+| AllWatcher           | Next                            |                                                          |
+| AllWatcher           | Stop                            |                                                          |
+| Annotations          | Get                             |                                                          |
+| Annotations          | Set                             |                                                          |
+| Application          | AddRelation                     | `POST /integrate`                                        |
+| Application          | AddUnits                        |                                                          |
+| Application          | ApplicationsInfo                | `GET /model/{model}/application/{application}`           |
+| Application          | CharmConfig                     |                                                          |
+| Application          | CharmRelations                  |                                                          |
+| Application          | Consume                         |                                                          |
+| Application          | Deploy                          |                                                          |
+| Application          | DeployFromRepository            | `POST /deploy?dry-run=false&trust=false`                 |
+| Application          | DestroyApplication              | `DELETE /model/{model}/application/{application}`        |
+| Application          | DestroyConsumedApplications     |                                                          |
+| Application          | DestroyRelation                 |                                                          |
+| Application          | DestroyUnit                     |                                                          |
+| Application          | Expose                          |                                                          |
+| Application          | Get                             |                                                          |
+| Application          | GetCharmURLOrigin               |                                                          |
+| Application          | GetConfig                       |                                                          |
+| Application          | GetConstraints                  |                                                          |
+| Application          | Leader                          |                                                          |
+| Application          | MergeBindings                   |                                                          |
+| Application          | ResolveUnitErrors               |                                                          |
+| Application          | ScaleApplications               |                                                          |
+| Application          | SetCharm                        | `PATCH /model/{model}/application/{application}/refresh` |
+| Application          | SetConfigs                      |                                                          |
+| Application          | SetConstraints                  |                                                          |
+| Application          | SetMetricCredentials            |                                                          |
+| Application          | SetRelationsSuspended           |                                                          |
+| Application          | Unexpose                        |                                                          |
+| Application          | UnitsInfo                       |                                                          |
+| Application          | UnsetApplicationsConfig         |                                                          |
+| Application          | UpdateApplicationBase           |                                                          |
+| ApplicationOffers    | ApplicationOffers               |                                                          |
+| ApplicationOffers    | DestroyOffers                   |                                                          |
+| ApplicationOffers    | FindApplicationOffers           |                                                          |
+| ApplicationOffers    | GetConsumeDetails               |                                                          |
+| ApplicationOffers    | ListApplicationOffers           |                                                          |
+| ApplicationOffers    | ModifyOfferAccess               |                                                          |
+| ApplicationOffers    | Offer                           |                                                          |
+| ApplicationOffers    | RemoteApplicationInfo           |                                                          |
+| Backup               | Create                          |                                                          |
+| Block                | List                            |                                                          |
+| Block                | SwitchBlockOff                  |                                                          |
+| Block                | SwitchBlockOn                   |                                                          |
+| Bundle               | ExportBundle                    |                                                          |
+| Bundle               | GetChanges                      |                                                          |
+| Bundle               | GetChangesMapArgs               |                                                          |
+| Charms               | AddCharm                        |                                                          |
+| Charms               | CharmInfo                       |                                                          |
+| Charms               | CheckCharmPlacement             |                                                          |
+| Charms               | GetDownloadInfos                |                                                          |
+| Charms               | IsMetered                       |                                                          |
+| Charms               | List                            |                                                          |
+| Charms               | ListCharmResources              |                                                          |
+| Charms               | ResolveCharms                   |                                                          |
+| Client               | FindTools                       |                                                          |
+| Client               | FullStatus                      |                                                          |
+| Client               | StatusHistory                   |                                                          |
+| Client               | WatchAll                        |                                                          |
+| Cloud                | AddCloud                        | `POST /clouds`                                           |
+| Cloud                | AddCredentials                  |                                                          |
+| Cloud                | CheckCredentialsModels          |                                                          |
+| Cloud                | Cloud                           | `GET /cloud/{cloud}`                                     |
+| Cloud                | CloudInfo                       | `GET /cloud/{cloud}`                                     |
+| Cloud                | Clouds                          | `GET /clouds/supported`                                  |
+| Cloud                | Credential                      |                                                          |
+| Cloud                | CredentialContents              |                                                          |
+| Cloud                | InstanceTypes                   |                                                          |
+| Cloud                | ListCloudInfo                   | `GET /clouds`                                            |
+| Cloud                | ModifyCloudAccess               | `PATCH /cloud/{cloud}/access`                            |
+| Cloud                | RemoveClouds                    | `DELETE /cloud/{cloud}`                                  |
+| Cloud                | RevokeCredentialsCheckModels    |                                                          |
+| Cloud                | UpdateCloud                     |                                                          |
+| Cloud                | UpdateCredentialsCheckModels    |                                                          |
+| Cloud                | UserCredentials                 |                                                          |
+| Controller           | AllModels                       |                                                          |
+| Controller           | CloudSpec                       |                                                          |
+| Controller           | ConfigSet                       |                                                          |
+| Controller           | ControllerAPIInfoForModels      |                                                          |
+| Controller           | ControllerConfig                |                                                          |
+| Controller           | ControllerVersion               |                                                          |
+| Controller           | DashboardConnectionInfo         |                                                          |
+| Controller           | DestroyController               |                                                          |
+| Controller           | GetCloudSpec                    |                                                          |
+| Controller           | GetControllerAccess             |                                                          |
+| Controller           | HostedModelConfigs              |                                                          |
+| Controller           | IdentityProviderURL             |                                                          |
+| Controller           | InitiateMigration               |                                                          |
+| Controller           | ListBlockedModels               |                                                          |
+| Controller           | ModelConfig                     |                                                          |
+| Controller           | ModelStatus                     |                                                          |
+| Controller           | ModifyControllerAccess          |                                                          |
+| Controller           | MongoVersion                    |                                                          |
+| Controller           | RemoveBlocks                    |                                                          |
+| Controller           | WatchAllModelSummaries          |                                                          |
+| Controller           | WatchAllModels                  |                                                          |
+| Controller           | WatchCloudSpecsChanges          |                                                          |
+| Controller           | WatchModelSummaries             |                                                          |
+| CredentialManager    | InvalidateModelCredential       |                                                          |
+| FirewallRules        | ListFirewallRules               |                                                          |
+| FirewallRules        | SetFirewallRules                |                                                          |
+| HighAvailability     | EnableHA                        |                                                          |
+| ImageMetaDataManager | Delete                          |                                                          |
+| ImageMetaDataManager | List                            |                                                          |
+| ImageMetaDataManager | Save                            |                                                          |
+| KeyManager           | AddKeys                         |                                                          |
+| KeyManager           | DeleteKeys                      |                                                          |
+| KeyManager           | ImportKeys                      |                                                          |
+| KeyManager           | ListKeys                        |                                                          |
+| MachineManager       | AddMachines                     |                                                          |
+| MachineManager       | DestroyMachineWithParams        |                                                          |
+| MachineManager       | GetUpgradeSeriesMessages        |                                                          |
+| MachineManager       | InstanceTypes                   |                                                          |
+| MachineManager       | ProvisioningScript              |                                                          |
+| MachineManager       | RetryProvisioning               |                                                          |
+| MachineManager       | UpgradeSeriesComplete           |                                                          |
+| MachineManager       | UpgradeSeriesPrepare            |                                                          |
+| MachineManager       | UpgradeSeriesValidate           |                                                          |
+| MachineManager       | WatchUpgradeSeriesNotifications |                                                          |
+| MetricsDebug         | GetMetrics                      |                                                          |
+| MetricsDebug         | SetMeterStatus                  |                                                          |
+| ModelConfig          | GetModelConstraints             |                                                          |
+| ModelConfig          | ModelGet                        |                                                          |
+| ModelConfig          | ModelSet                        |                                                          |
+| ModelConfig          | ModelUnset                      |                                                          |
+| ModelConfig          | SLALevel                        |                                                          |
+| ModelConfig          | Sequences                       |                                                          |
+| ModelConfig          | SetModelConstraints             |                                                          |
+| ModelConfig          | SetSLALevel                     |                                                          |
+| ModelGeneration      | AbortBranch                     |                                                          |
+| ModelGeneration      | AddBranch                       |                                                          |
+| ModelGeneration      | BranchInfo                      |                                                          |
+| ModelGeneration      | CommitBranch                    |                                                          |
+| ModelGeneration      | HasActiveBranch                 |                                                          |
+| ModelGeneration      | ListCommits                     |                                                          |
+| ModelGeneration      | ShowCommit                      |                                                          |
+| ModelGeneration      | TrackBranch                     |                                                          |
+| ModelManager         | ChangeModelCredential           | `PATCH /model/{model}/credential`                        |
+| ModelManager         | CreateModel                     | `POST /models`                                           |
+| ModelManager         | DestroyModels                   | `DELETE /model/{model}`                                  |
+| ModelManager         | DumpModels                      | `GET /models?detailed=true&all=true`                     |
+| ModelManager         | DumpModelsDB                    | N/A                                                      |
+| ModelManager         | ListModelSummaries              | `GET /models?detailed=true`                              |
+| ModelManager         | ListModels                      | `GET /models`                                            |
+| ModelManager         | ModelDefaultsForClouds          | `GET /models/defaults`                                   |
+| ModelManager         | ModelInfo                       | `GET /model/{model}`                                     |
+| ModelManager         | ModelStatus                     | `GET /model/{model}/status`                              |
+| ModelManager         | ModifyModelAccess               | `PATCH /model/{model}/access`                            |
+| ModelManager         | SetModelDefaults                | `PATCH /models/defaults`                                 |
+| ModelManager         | UnsetModelDefaults              | `PATCH /models/defaults`                                 |
+| ModelUpgrader        | AbortModelUpgrade               |                                                          |
+| ModelUpgrader        | UpgradeModel                    |                                                          |
+| Payloads             | List                            |                                                          |
+| Pinger               | Ping                            |                                                          |
+| Pinger               | Stop                            |                                                          |
+| Resources            | AddPendingResources             |                                                          |
+| Resources            | ListResources                   |                                                          |
+| SSHClient            | AllAddresses                    |                                                          |
+| SSHClient            | ModelCredentialForSSH           |                                                          |
+| SSHClient            | PrivateAddress                  |                                                          |
+| SSHClient            | Proxy                           |                                                          |
+| SSHClient            | PublicAddress                   |                                                          |
+| SSHClient            | PublicKeys                      |                                                          |
+| SecretBackends       | AddSecretBackends               |                                                          |
+| SecretBackends       | ListSecretBackends              |                                                          |
+| SecretBackends       | RemoveSecretBackends            |                                                          |
+| SecretBackends       | UpdateSecretBackends            |                                                          |
+| Secrets              | ListSecrets                     |                                                          |
+| Spaces               | CreateSpaces                    |                                                          |
+| Spaces               | ListSpaces                      |                                                          |
+| Spaces               | MoveSubnets                     |                                                          |
+| Spaces               | ReloadSpaces                    |                                                          |
+| Spaces               | RemoveSpace                     |                                                          |
+| Spaces               | RenameSpace                     |                                                          |
+| Spaces               | ShowSpace                       |                                                          |
+| Storage              | AddToUnit                       |                                                          |
+| Storage              | Attach                          |                                                          |
+| Storage              | CreatePool                      |                                                          |
+| Storage              | DetachStorage                   |                                                          |
+| Storage              | Import                          |                                                          |
+| Storage              | ListFilesystems                 |                                                          |
+| Storage              | ListPools                       |                                                          |
+| Storage              | ListStorageDetails              |                                                          |
+| Storage              | ListVolumes                     |                                                          |
+| Storage              | Remove                          |                                                          |
+| Storage              | RemovePool                      |                                                          |
+| Storage              | StorageDetails                  |                                                          |
+| Storage              | UpdatePool                      |                                                          |
+| Subnets              | AllZones                        |                                                          |
+| Subnets              | ListSubnets                     |                                                          |
+| Subnets              | SubnetsByCIDR                   |                                                          |
+| UserManager          | AddUser                         | `POST /users`                                            |
+| UserManager          | DisableUser                     | `PATCH /user/{user}`                                     |
+| UserManager          | EnableUser                      | `PATCH /user/{user}`                                     |
+| UserManager          | ModelUserInfo                   | `GET /models?user={user}`                                |
+| UserManager          | RemoveUser                      | `DELETE /user/{user}`                                    |
+| UserManager          | ResetPassword                   | `PATCH /user/{user}`                                     |
+| UserManager          | SetPassword                     | `PATCH /user/{user}`                                     |
+| UserManager          | UserInfo                        | `GET /user/{user}`                                       |

--- a/README.md
+++ b/README.md
@@ -51,219 +51,219 @@ go run schemagen.go -admin-facades -facade-group client ./schemas/client-schemas
 
 This table tracks progress through the redesign of the Juju client API:
 
-| Facade               | Facade Call                     | API Path                                                                |
-| :------------------- | :------------------------------ | :---------------------------------------------------------------------- |
-| Action               | Actions                         |                                                                         |
-| Action               | ApplicationsCharmsActions       |                                                                         |
-| Action               | Cancel                          |                                                                         |
-| Action               | EnqueueOperation                |                                                                         |
-| Action               | ListOperations                  |                                                                         |
-| Action               | Operations                      |                                                                         |
-| Action               | Run                             |                                                                         |
-| Action               | RunOnAllMachines                |                                                                         |
-| Action               | WatchActionsProgress            |                                                                         |
-| Admin                | Login                           |                                                                         |
-| Admin                | RedirectInfo                    |                                                                         |
-| AllModelWatcher      | Next                            |                                                                         |
-| AllModelWatcher      | Stop                            |                                                                         |
-| AllWatcher           | Next                            |                                                                         |
-| AllWatcher           | Stop                            |                                                                         |
-| Annotations          | Get                             |                                                                         |
-| Annotations          | Set                             |                                                                         |
-| Application          | AddRelation                     | `POST /application/relate`                                              |
-| Application          | AddUnits                        |                                                                         |
-| Application          | ApplicationsInfo                | `GET /application/{application}`                                        |
-| Application          | CharmConfig                     |                                                                         |
-| Application          | CharmRelations                  |                                                                         |
-| Application          | Consume                         |                                                                         |
-| Application          | Deploy                          |                                                                         |
-| Application          | DeployFromRepository            | `POST /application/{application}?force=false&dry-run=false&trust=false` |
-| Application          | DestroyApplication              | `DELETE /application/{application}`                                     |
-| Application          | DestroyConsumedApplications     |                                                                         |
-| Application          | DestroyRelation                 |                                                                         |
-| Application          | DestroyUnit                     |                                                                         |
-| Application          | Expose                          |                                                                         |
-| Application          | Get                             |                                                                         |
-| Application          | GetCharmURLOrigin               |                                                                         |
-| Application          | GetConfig                       |                                                                         |
-| Application          | GetConstraints                  |                                                                         |
-| Application          | Leader                          |                                                                         |
-| Application          | MergeBindings                   |                                                                         |
-| Application          | ResolveUnitErrors               |                                                                         |
-| Application          | ScaleApplications               |                                                                         |
-| Application          | SetCharm                        | `PATCH /application/{application}`                                      |
-| Application          | SetConfigs                      |                                                                         |
-| Application          | SetConstraints                  |                                                                         |
-| Application          | SetMetricCredentials            |                                                                         |
-| Application          | SetRelationsSuspended           |                                                                         |
-| Application          | Unexpose                        |                                                                         |
-| Application          | UnitsInfo                       |                                                                         |
-| Application          | UnsetApplicationsConfig         |                                                                         |
-| Application          | UpdateApplicationBase           |                                                                         |
-| ApplicationOffers    | ApplicationOffers               |                                                                         |
-| ApplicationOffers    | DestroyOffers                   |                                                                         |
-| ApplicationOffers    | FindApplicationOffers           |                                                                         |
-| ApplicationOffers    | GetConsumeDetails               |                                                                         |
-| ApplicationOffers    | ListApplicationOffers           |                                                                         |
-| ApplicationOffers    | ModifyOfferAccess               |                                                                         |
-| ApplicationOffers    | Offer                           |                                                                         |
-| ApplicationOffers    | RemoteApplicationInfo           |                                                                         |
-| Backup               | Create                          |                                                                         |
-| Block                | List                            |                                                                         |
-| Block                | SwitchBlockOff                  |                                                                         |
-| Block                | SwitchBlockOn                   |                                                                         |
-| Bundle               | ExportBundle                    |                                                                         |
-| Bundle               | GetChanges                      |                                                                         |
-| Bundle               | GetChangesMapArgs               |                                                                         |
-| Charms               | AddCharm                        |                                                                         |
-| Charms               | CharmInfo                       |                                                                         |
-| Charms               | CheckCharmPlacement             |                                                                         |
-| Charms               | GetDownloadInfos                |                                                                         |
-| Charms               | IsMetered                       |                                                                         |
-| Charms               | List                            |                                                                         |
-| Charms               | ListCharmResources              |                                                                         |
-| Charms               | ResolveCharms                   |                                                                         |
-| Client               | FindTools                       |                                                                         |
-| Client               | FullStatus                      |                                                                         |
-| Client               | StatusHistory                   |                                                                         |
-| Client               | WatchAll                        |                                                                         |
-| Cloud                | AddCloud                        | `POST /clouds`                                                          |
-| Cloud                | AddCredentials                  |                                                                         |
-| Cloud                | CheckCredentialsModels          |                                                                         |
-| Cloud                | Cloud                           | `GET /cloud/{cloud}`                                                    |
-| Cloud                | CloudInfo                       | `GET /cloud/{cloud}`                                                    |
-| Cloud                | Clouds                          | `GET /clouds/supported`                                                 |
-| Cloud                | Credential                      |                                                                         |
-| Cloud                | CredentialContents              |                                                                         |
-| Cloud                | InstanceTypes                   |                                                                         |
-| Cloud                | ListCloudInfo                   | `GET /clouds`                                                           |
-| Cloud                | ModifyCloudAccess               | `PATCH /cloud/{cloud}/access`                                           |
-| Cloud                | RemoveClouds                    | `DELETE /cloud/{cloud}`                                                 |
-| Cloud                | RevokeCredentialsCheckModels    |                                                                         |
-| Cloud                | UpdateCloud                     |                                                                         |
-| Cloud                | UpdateCredentialsCheckModels    |                                                                         |
-| Cloud                | UserCredentials                 |                                                                         |
-| Controller           | AllModels                       |                                                                         |
-| Controller           | CloudSpec                       |                                                                         |
-| Controller           | ConfigSet                       |                                                                         |
-| Controller           | ControllerAPIInfoForModels      |                                                                         |
-| Controller           | ControllerConfig                |                                                                         |
-| Controller           | ControllerVersion               |                                                                         |
-| Controller           | DashboardConnectionInfo         |                                                                         |
-| Controller           | DestroyController               |                                                                         |
-| Controller           | GetCloudSpec                    |                                                                         |
-| Controller           | GetControllerAccess             |                                                                         |
-| Controller           | HostedModelConfigs              |                                                                         |
-| Controller           | IdentityProviderURL             |                                                                         |
-| Controller           | InitiateMigration               |                                                                         |
-| Controller           | ListBlockedModels               |                                                                         |
-| Controller           | ModelConfig                     |                                                                         |
-| Controller           | ModelStatus                     |                                                                         |
-| Controller           | ModifyControllerAccess          |                                                                         |
-| Controller           | MongoVersion                    |                                                                         |
-| Controller           | RemoveBlocks                    |                                                                         |
-| Controller           | WatchAllModelSummaries          |                                                                         |
-| Controller           | WatchAllModels                  |                                                                         |
-| Controller           | WatchCloudSpecsChanges          |                                                                         |
-| Controller           | WatchModelSummaries             |                                                                         |
-| CredentialManager    | InvalidateModelCredential       |                                                                         |
-| FirewallRules        | ListFirewallRules               |                                                                         |
-| FirewallRules        | SetFirewallRules                |                                                                         |
-| HighAvailability     | EnableHA                        |                                                                         |
-| ImageMetaDataManager | Delete                          |                                                                         |
-| ImageMetaDataManager | List                            |                                                                         |
-| ImageMetaDataManager | Save                            |                                                                         |
-| KeyManager           | AddKeys                         |                                                                         |
-| KeyManager           | DeleteKeys                      |                                                                         |
-| KeyManager           | ImportKeys                      |                                                                         |
-| KeyManager           | ListKeys                        |                                                                         |
-| MachineManager       | AddMachines                     |                                                                         |
-| MachineManager       | DestroyMachineWithParams        |                                                                         |
-| MachineManager       | GetUpgradeSeriesMessages        |                                                                         |
-| MachineManager       | InstanceTypes                   |                                                                         |
-| MachineManager       | ProvisioningScript              |                                                                         |
-| MachineManager       | RetryProvisioning               |                                                                         |
-| MachineManager       | UpgradeSeriesComplete           |                                                                         |
-| MachineManager       | UpgradeSeriesPrepare            |                                                                         |
-| MachineManager       | UpgradeSeriesValidate           |                                                                         |
-| MachineManager       | WatchUpgradeSeriesNotifications |                                                                         |
-| MetricsDebug         | GetMetrics                      |                                                                         |
-| MetricsDebug         | SetMeterStatus                  |                                                                         |
-| ModelConfig          | GetModelConstraints             |                                                                         |
-| ModelConfig          | ModelGet                        |                                                                         |
-| ModelConfig          | ModelSet                        |                                                                         |
-| ModelConfig          | ModelUnset                      |                                                                         |
-| ModelConfig          | SLALevel                        |                                                                         |
-| ModelConfig          | Sequences                       |                                                                         |
-| ModelConfig          | SetModelConstraints             |                                                                         |
-| ModelConfig          | SetSLALevel                     |                                                                         |
-| ModelGeneration      | AbortBranch                     |                                                                         |
-| ModelGeneration      | AddBranch                       |                                                                         |
-| ModelGeneration      | BranchInfo                      |                                                                         |
-| ModelGeneration      | CommitBranch                    |                                                                         |
-| ModelGeneration      | HasActiveBranch                 |                                                                         |
-| ModelGeneration      | ListCommits                     |                                                                         |
-| ModelGeneration      | ShowCommit                      |                                                                         |
-| ModelGeneration      | TrackBranch                     |                                                                         |
-| ModelManager         | ChangeModelCredential           | `PATCH /model/{model}/credential`                                       |
-| ModelManager         | CreateModel                     | `POST /models`                                                          |
-| ModelManager         | DestroyModels                   | `DELETE /model/{model}`                                                 |
-| ModelManager         | DumpModels                      | `GET /models?detailed=true&all=true`                                    |
-| ModelManager         | DumpModelsDB                    | N/A                                                                     |
-| ModelManager         | ListModelSummaries              | `GET /models?detailed=true`                                             |
-| ModelManager         | ListModels                      | `GET /models`                                                           |
-| ModelManager         | ModelDefaultsForClouds          | `GET /models/defaults`                                                  |
-| ModelManager         | ModelInfo                       | `GET /model/{model}`                                                    |
-| ModelManager         | ModelStatus                     | `GET /model/{model}/status`                                             |
-| ModelManager         | ModifyModelAccess               | `PATCH /model/{model}/access`                                           |
-| ModelManager         | SetModelDefaults                | `PATCH /models/defaults`                                                |
-| ModelManager         | UnsetModelDefaults              | `PATCH /models/defaults`                                                |
-| ModelUpgrader        | AbortModelUpgrade               |                                                                         |
-| ModelUpgrader        | UpgradeModel                    |                                                                         |
-| Payloads             | List                            |                                                                         |
-| Pinger               | Ping                            |                                                                         |
-| Pinger               | Stop                            |                                                                         |
-| Resources            | AddPendingResources             |                                                                         |
-| Resources            | ListResources                   |                                                                         |
-| SSHClient            | AllAddresses                    |                                                                         |
-| SSHClient            | ModelCredentialForSSH           |                                                                         |
-| SSHClient            | PrivateAddress                  |                                                                         |
-| SSHClient            | Proxy                           |                                                                         |
-| SSHClient            | PublicAddress                   |                                                                         |
-| SSHClient            | PublicKeys                      |                                                                         |
-| SecretBackends       | AddSecretBackends               |                                                                         |
-| SecretBackends       | ListSecretBackends              |                                                                         |
-| SecretBackends       | RemoveSecretBackends            |                                                                         |
-| SecretBackends       | UpdateSecretBackends            |                                                                         |
-| Secrets              | ListSecrets                     |                                                                         |
-| Spaces               | CreateSpaces                    |                                                                         |
-| Spaces               | ListSpaces                      |                                                                         |
-| Spaces               | MoveSubnets                     |                                                                         |
-| Spaces               | ReloadSpaces                    |                                                                         |
-| Spaces               | RemoveSpace                     |                                                                         |
-| Spaces               | RenameSpace                     |                                                                         |
-| Spaces               | ShowSpace                       |                                                                         |
-| Storage              | AddToUnit                       |                                                                         |
-| Storage              | Attach                          |                                                                         |
-| Storage              | CreatePool                      |                                                                         |
-| Storage              | DetachStorage                   |                                                                         |
-| Storage              | Import                          |                                                                         |
-| Storage              | ListFilesystems                 |                                                                         |
-| Storage              | ListPools                       |                                                                         |
-| Storage              | ListStorageDetails              |                                                                         |
-| Storage              | ListVolumes                     |                                                                         |
-| Storage              | Remove                          |                                                                         |
-| Storage              | RemovePool                      |                                                                         |
-| Storage              | StorageDetails                  |                                                                         |
-| Storage              | UpdatePool                      |                                                                         |
-| Subnets              | AllZones                        |                                                                         |
-| Subnets              | ListSubnets                     |                                                                         |
-| Subnets              | SubnetsByCIDR                   |                                                                         |
-| UserManager          | AddUser                         | `POST /users`                                                           |
-| UserManager          | DisableUser                     | `PATCH /user/{user}`                                                    |
-| UserManager          | EnableUser                      | `PATCH /user/{user}`                                                    |
-| UserManager          | ModelUserInfo                   | `GET /models?user={user}`                                               |
-| UserManager          | RemoveUser                      | `DELETE /user/{user}`                                                   |
-| UserManager          | ResetPassword                   | `PATCH /user/{user}`                                                    |
-| UserManager          | SetPassword                     | `PATCH /user/{user}`                                                    |
-| UserManager          | UserInfo                        | `GET /user/{user}`                                                      |
+| Facade               | Facade Call                     | API Path                                                                                     |
+| :------------------- | :------------------------------ |:---------------------------------------------------------------------------------------------|
+| Action               | Actions                         |                                                                                              |
+| Action               | ApplicationsCharmsActions       |                                                                                              |
+| Action               | Cancel                          |                                                                                              |
+| Action               | EnqueueOperation                |                                                                                              |
+| Action               | ListOperations                  |                                                                                              |
+| Action               | Operations                      |                                                                                              |
+| Action               | Run                             |                                                                                              |
+| Action               | RunOnAllMachines                |                                                                                              |
+| Action               | WatchActionsProgress            |                                                                                              |
+| Admin                | Login                           |                                                                                              |
+| Admin                | RedirectInfo                    |                                                                                              |
+| AllModelWatcher      | Next                            |                                                                                              |
+| AllModelWatcher      | Stop                            |                                                                                              |
+| AllWatcher           | Next                            |                                                                                              |
+| AllWatcher           | Stop                            |                                                                                              |
+| Annotations          | Get                             |                                                                                              |
+| Annotations          | Set                             |                                                                                              |
+| Application          | AddRelation                     | `POST /integrate`                                                                            |
+| Application          | AddUnits                        |                                                                                              |
+| Application          | ApplicationsInfo                | `GET /model{model}/application/{application}`                                                |
+| Application          | CharmConfig                     |                                                                                              |
+| Application          | CharmRelations                  |                                                                                              |
+| Application          | Consume                         |                                                                                              |
+| Application          | Deploy                          |                                                                                              |
+| Application          | DeployFromRepository            | `POST /model/{model}/application/{application}/deploy?force=false&dry-run=false&trust=false` |
+| Application          | DestroyApplication              | `DELETE /model/{model}/application/{application}`                                            |
+| Application          | DestroyConsumedApplications     |                                                                                              |
+| Application          | DestroyRelation                 |                                                                                              |
+| Application          | DestroyUnit                     |                                                                                              |
+| Application          | Expose                          |                                                                                              |
+| Application          | Get                             |                                                                                              |
+| Application          | GetCharmURLOrigin               |                                                                                              |
+| Application          | GetConfig                       |                                                                                              |
+| Application          | GetConstraints                  |                                                                                              |
+| Application          | Leader                          |                                                                                              |
+| Application          | MergeBindings                   |                                                                                              |
+| Application          | ResolveUnitErrors               |                                                                                              |
+| Application          | ScaleApplications               |                                                                                              |
+| Application          | SetCharm                        | `PATCH /model/{model}/application/{application}/refresh`                                     |
+| Application          | SetConfigs                      |                                                                                              |
+| Application          | SetConstraints                  |                                                                                              |
+| Application          | SetMetricCredentials            |                                                                                              |
+| Application          | SetRelationsSuspended           |                                                                                              |
+| Application          | Unexpose                        |                                                                                              |
+| Application          | UnitsInfo                       |                                                                                              |
+| Application          | UnsetApplicationsConfig         |                                                                                              |
+| Application          | UpdateApplicationBase           |                                                                                              |
+| ApplicationOffers    | ApplicationOffers               |                                                                                              |
+| ApplicationOffers    | DestroyOffers                   |                                                                                              |
+| ApplicationOffers    | FindApplicationOffers           |                                                                                              |
+| ApplicationOffers    | GetConsumeDetails               |                                                                                              |
+| ApplicationOffers    | ListApplicationOffers           |                                                                                              |
+| ApplicationOffers    | ModifyOfferAccess               |                                                                                              |
+| ApplicationOffers    | Offer                           |                                                                                              |
+| ApplicationOffers    | RemoteApplicationInfo           |                                                                                              |
+| Backup               | Create                          |                                                                                              |
+| Block                | List                            |                                                                                              |
+| Block                | SwitchBlockOff                  |                                                                                              |
+| Block                | SwitchBlockOn                   |                                                                                              |
+| Bundle               | ExportBundle                    |                                                                                              |
+| Bundle               | GetChanges                      |                                                                                              |
+| Bundle               | GetChangesMapArgs               |                                                                                              |
+| Charms               | AddCharm                        |                                                                                              |
+| Charms               | CharmInfo                       |                                                                                              |
+| Charms               | CheckCharmPlacement             |                                                                                              |
+| Charms               | GetDownloadInfos                |                                                                                              |
+| Charms               | IsMetered                       |                                                                                              |
+| Charms               | List                            |                                                                                              |
+| Charms               | ListCharmResources              |                                                                                              |
+| Charms               | ResolveCharms                   |                                                                                              |
+| Client               | FindTools                       |                                                                                              |
+| Client               | FullStatus                      |                                                                                              |
+| Client               | StatusHistory                   |                                                                                              |
+| Client               | WatchAll                        |                                                                                              |
+| Cloud                | AddCloud                        | `POST /clouds`                                                                               |
+| Cloud                | AddCredentials                  |                                                                                              |
+| Cloud                | CheckCredentialsModels          |                                                                                              |
+| Cloud                | Cloud                           | `GET /cloud/{cloud}`                                                                         |
+| Cloud                | CloudInfo                       | `GET /cloud/{cloud}`                                                                         |
+| Cloud                | Clouds                          | `GET /clouds/supported`                                                                      |
+| Cloud                | Credential                      |                                                                                              |
+| Cloud                | CredentialContents              |                                                                                              |
+| Cloud                | InstanceTypes                   |                                                                                              |
+| Cloud                | ListCloudInfo                   | `GET /clouds`                                                                                |
+| Cloud                | ModifyCloudAccess               | `PATCH /cloud/{cloud}/access`                                                                |
+| Cloud                | RemoveClouds                    | `DELETE /cloud/{cloud}`                                                                      |
+| Cloud                | RevokeCredentialsCheckModels    |                                                                                              |
+| Cloud                | UpdateCloud                     |                                                                                              |
+| Cloud                | UpdateCredentialsCheckModels    |                                                                                              |
+| Cloud                | UserCredentials                 |                                                                                              |
+| Controller           | AllModels                       |                                                                                              |
+| Controller           | CloudSpec                       |                                                                                              |
+| Controller           | ConfigSet                       |                                                                                              |
+| Controller           | ControllerAPIInfoForModels      |                                                                                              |
+| Controller           | ControllerConfig                |                                                                                              |
+| Controller           | ControllerVersion               |                                                                                              |
+| Controller           | DashboardConnectionInfo         |                                                                                              |
+| Controller           | DestroyController               |                                                                                              |
+| Controller           | GetCloudSpec                    |                                                                                              |
+| Controller           | GetControllerAccess             |                                                                                              |
+| Controller           | HostedModelConfigs              |                                                                                              |
+| Controller           | IdentityProviderURL             |                                                                                              |
+| Controller           | InitiateMigration               |                                                                                              |
+| Controller           | ListBlockedModels               |                                                                                              |
+| Controller           | ModelConfig                     |                                                                                              |
+| Controller           | ModelStatus                     |                                                                                              |
+| Controller           | ModifyControllerAccess          |                                                                                              |
+| Controller           | MongoVersion                    |                                                                                              |
+| Controller           | RemoveBlocks                    |                                                                                              |
+| Controller           | WatchAllModelSummaries          |                                                                                              |
+| Controller           | WatchAllModels                  |                                                                                              |
+| Controller           | WatchCloudSpecsChanges          |                                                                                              |
+| Controller           | WatchModelSummaries             |                                                                                              |
+| CredentialManager    | InvalidateModelCredential       |                                                                                              |
+| FirewallRules        | ListFirewallRules               |                                                                                              |
+| FirewallRules        | SetFirewallRules                |                                                                                              |
+| HighAvailability     | EnableHA                        |                                                                                              |
+| ImageMetaDataManager | Delete                          |                                                                                              |
+| ImageMetaDataManager | List                            |                                                                                              |
+| ImageMetaDataManager | Save                            |                                                                                              |
+| KeyManager           | AddKeys                         |                                                                                              |
+| KeyManager           | DeleteKeys                      |                                                                                              |
+| KeyManager           | ImportKeys                      |                                                                                              |
+| KeyManager           | ListKeys                        |                                                                                              |
+| MachineManager       | AddMachines                     |                                                                                              |
+| MachineManager       | DestroyMachineWithParams        |                                                                                              |
+| MachineManager       | GetUpgradeSeriesMessages        |                                                                                              |
+| MachineManager       | InstanceTypes                   |                                                                                              |
+| MachineManager       | ProvisioningScript              |                                                                                              |
+| MachineManager       | RetryProvisioning               |                                                                                              |
+| MachineManager       | UpgradeSeriesComplete           |                                                                                              |
+| MachineManager       | UpgradeSeriesPrepare            |                                                                                              |
+| MachineManager       | UpgradeSeriesValidate           |                                                                                              |
+| MachineManager       | WatchUpgradeSeriesNotifications |                                                                                              |
+| MetricsDebug         | GetMetrics                      |                                                                                              |
+| MetricsDebug         | SetMeterStatus                  |                                                                                              |
+| ModelConfig          | GetModelConstraints             |                                                                                              |
+| ModelConfig          | ModelGet                        |                                                                                              |
+| ModelConfig          | ModelSet                        |                                                                                              |
+| ModelConfig          | ModelUnset                      |                                                                                              |
+| ModelConfig          | SLALevel                        |                                                                                              |
+| ModelConfig          | Sequences                       |                                                                                              |
+| ModelConfig          | SetModelConstraints             |                                                                                              |
+| ModelConfig          | SetSLALevel                     |                                                                                              |
+| ModelGeneration      | AbortBranch                     |                                                                                              |
+| ModelGeneration      | AddBranch                       |                                                                                              |
+| ModelGeneration      | BranchInfo                      |                                                                                              |
+| ModelGeneration      | CommitBranch                    |                                                                                              |
+| ModelGeneration      | HasActiveBranch                 |                                                                                              |
+| ModelGeneration      | ListCommits                     |                                                                                              |
+| ModelGeneration      | ShowCommit                      |                                                                                              |
+| ModelGeneration      | TrackBranch                     |                                                                                              |
+| ModelManager         | ChangeModelCredential           | `PATCH /model/{model}/credential`                                                            |
+| ModelManager         | CreateModel                     | `POST /models`                                                                               |
+| ModelManager         | DestroyModels                   | `DELETE /model/{model}`                                                                      |
+| ModelManager         | DumpModels                      | `GET /models?detailed=true&all=true`                                                         |
+| ModelManager         | DumpModelsDB                    | N/A                                                                                          |
+| ModelManager         | ListModelSummaries              | `GET /models?detailed=true`                                                                  |
+| ModelManager         | ListModels                      | `GET /models`                                                                                |
+| ModelManager         | ModelDefaultsForClouds          | `GET /models/defaults`                                                                       |
+| ModelManager         | ModelInfo                       | `GET /model/{model}`                                                                         |
+| ModelManager         | ModelStatus                     | `GET /model/{model}/status`                                                                  |
+| ModelManager         | ModifyModelAccess               | `PATCH /model/{model}/access`                                                                |
+| ModelManager         | SetModelDefaults                | `PATCH /models/defaults`                                                                     |
+| ModelManager         | UnsetModelDefaults              | `PATCH /models/defaults`                                                                     |
+| ModelUpgrader        | AbortModelUpgrade               |                                                                                              |
+| ModelUpgrader        | UpgradeModel                    |                                                                                              |
+| Payloads             | List                            |                                                                                              |
+| Pinger               | Ping                            |                                                                                              |
+| Pinger               | Stop                            |                                                                                              |
+| Resources            | AddPendingResources             |                                                                                              |
+| Resources            | ListResources                   |                                                                                              |
+| SSHClient            | AllAddresses                    |                                                                                              |
+| SSHClient            | ModelCredentialForSSH           |                                                                                              |
+| SSHClient            | PrivateAddress                  |                                                                                              |
+| SSHClient            | Proxy                           |                                                                                              |
+| SSHClient            | PublicAddress                   |                                                                                              |
+| SSHClient            | PublicKeys                      |                                                                                              |
+| SecretBackends       | AddSecretBackends               |                                                                                              |
+| SecretBackends       | ListSecretBackends              |                                                                                              |
+| SecretBackends       | RemoveSecretBackends            |                                                                                              |
+| SecretBackends       | UpdateSecretBackends            |                                                                                              |
+| Secrets              | ListSecrets                     |                                                                                              |
+| Spaces               | CreateSpaces                    |                                                                                              |
+| Spaces               | ListSpaces                      |                                                                                              |
+| Spaces               | MoveSubnets                     |                                                                                              |
+| Spaces               | ReloadSpaces                    |                                                                                              |
+| Spaces               | RemoveSpace                     |                                                                                              |
+| Spaces               | RenameSpace                     |                                                                                              |
+| Spaces               | ShowSpace                       |                                                                                              |
+| Storage              | AddToUnit                       |                                                                                              |
+| Storage              | Attach                          |                                                                                              |
+| Storage              | CreatePool                      |                                                                                              |
+| Storage              | DetachStorage                   |                                                                                              |
+| Storage              | Import                          |                                                                                              |
+| Storage              | ListFilesystems                 |                                                                                              |
+| Storage              | ListPools                       |                                                                                              |
+| Storage              | ListStorageDetails              |                                                                                              |
+| Storage              | ListVolumes                     |                                                                                              |
+| Storage              | Remove                          |                                                                                              |
+| Storage              | RemovePool                      |                                                                                              |
+| Storage              | StorageDetails                  |                                                                                              |
+| Storage              | UpdatePool                      |                                                                                              |
+| Subnets              | AllZones                        |                                                                                              |
+| Subnets              | ListSubnets                     |                                                                                              |
+| Subnets              | SubnetsByCIDR                   |                                                                                              |
+| UserManager          | AddUser                         | `POST /users`                                                                                |
+| UserManager          | DisableUser                     | `PATCH /user/{user}`                                                                         |
+| UserManager          | EnableUser                      | `PATCH /user/{user}`                                                                         |
+| UserManager          | ModelUserInfo                   | `GET /models?user={user}`                                                                    |
+| UserManager          | RemoveUser                      | `DELETE /user/{user}`                                                                        |
+| UserManager          | ResetPassword                   | `PATCH /user/{user}`                                                                         |
+| UserManager          | SetPassword                     | `PATCH /user/{user}`                                                                         |
+| UserManager          | UserInfo                        | `GET /user/{user}`                                                                           |

--- a/README.md
+++ b/README.md
@@ -259,11 +259,11 @@ This table tracks progress through the redesign of the Juju client API:
 | Subnets              | AllZones                        |                                      |
 | Subnets              | ListSubnets                     |                                      |
 | Subnets              | SubnetsByCIDR                   |                                      |
-| UserManager          | AddUser                         |                                      |
-| UserManager          | DisableUser                     |                                      |
-| UserManager          | EnableUser                      |                                      |
-| UserManager          | ModelUserInfo                   |                                      |
-| UserManager          | RemoveUser                      |                                      |
-| UserManager          | ResetPassword                   |                                      |
-| UserManager          | SetPassword                     |                                      |
-| UserManager          | UserInfo                        |                                      |
+| UserManager          | AddUser                         | `POST /users`                        |
+| UserManager          | DisableUser                     | `PATCH /user/{name}`                 |
+| UserManager          | EnableUser                      | `PATCH /user/{name}`                 |
+| UserManager          | ModelUserInfo                   | `GET /models?user={name}`            |
+| UserManager          | RemoveUser                      | `DELETE /user/{name}`                |
+| UserManager          | ResetPassword                   | `PATCH /user/{name}`                 |
+| UserManager          | SetPassword                     | `PATCH /user/{name}`                 |
+| UserManager          | UserInfo                        | `GET /user/{name}`                   |

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This table tracks progress through the redesign of the Juju client API:
 | Application          | Consume                         |                                                                                              |
 | Application          | Deploy                          |                                                                                              |
 | Application          | DeployFromRepository            | `POST /model/{model}/application/{application}/deploy&dry-run=false&trust=false` |
-| Application          | DestroyApplication              | `DELETE /model/{model}/application/{application}?force=false`                                            |
+| Application          | DestroyApplication              | `DELETE /model/{model}/application/{application}`                                            |
 | Application          | DestroyConsumedApplications     |                                                                                              |
 | Application          | DestroyRelation                 |                                                                                              |
 | Application          | DestroyUnit                     |                                                                                              |
@@ -91,7 +91,7 @@ This table tracks progress through the redesign of the Juju client API:
 | Application          | MergeBindings                   |                                                                                              |
 | Application          | ResolveUnitErrors               |                                                                                              |
 | Application          | ScaleApplications               |                                                                                              |
-| Application          | SetCharm                        | `PATCH /model/{model}/application/{application}/refresh?force=false&dry-run=false`           |
+| Application          | SetCharm                        | `PATCH /model/{model}/application/{application}/refresh`           |
 | Application          | SetConfigs                      |                                                                                              |
 | Application          | SetConstraints                  |                                                                                              |
 | Application          | SetMetricCredentials            |                                                                                              |

--- a/README.md
+++ b/README.md
@@ -51,219 +51,219 @@ go run schemagen.go -admin-facades -facade-group client ./schemas/client-schemas
 
 This table tracks progress through the redesign of the Juju client API:
 
-| Facade               | Facade Call                     | API Path                                                         |
-| :------------------- | :------------------------------ | :--------------------------------------------------------------- |
-| Action               | Actions                         |                                                                  |
-| Action               | ApplicationsCharmsActions       |                                                                  |
-| Action               | Cancel                          |                                                                  |
-| Action               | EnqueueOperation                |                                                                  |
-| Action               | ListOperations                  |                                                                  |
-| Action               | Operations                      |                                                                  |
-| Action               | Run                             |                                                                  |
-| Action               | RunOnAllMachines                |                                                                  |
-| Action               | WatchActionsProgress            |                                                                  |
-| Admin                | Login                           |                                                                  |
-| Admin                | RedirectInfo                    |                                                                  |
-| AllModelWatcher      | Next                            |                                                                  |
-| AllModelWatcher      | Stop                            |                                                                  |
-| AllWatcher           | Next                            |                                                                  |
-| AllWatcher           | Stop                            |                                                                  |
-| Annotations          | Get                             |                                                                  |
-| Annotations          | Set                             |                                                                  |
-| Application          | AddRelation                     | `POST /application/relate`                                       |
-| Application          | AddUnits                        |                                                                  |
-| Application          | ApplicationsInfo                | `GET /application/{name}`                                        |
-| Application          | CharmConfig                     |                                                                  |
-| Application          | CharmRelations                  |                                                                  |
-| Application          | Consume                         |                                                                  |
-| Application          | Deploy                          |                                                                  |
-| Application          | DeployFromRepository            | `POST /application/{name}?force=false&dry-run=false&trust=false` |
-| Application          | DestroyApplication              | `DELETE /application/{name}`                                     |
-| Application          | DestroyConsumedApplications     |                                                                  |
-| Application          | DestroyRelation                 |                                                                  |
-| Application          | DestroyUnit                     |                                                                  |
-| Application          | Expose                          |                                                                  |
-| Application          | Get                             |                                                                  |
-| Application          | GetCharmURLOrigin               |                                                                  |
-| Application          | GetConfig                       |                                                                  |
-| Application          | GetConstraints                  |                                                                  |
-| Application          | Leader                          |                                                                  |
-| Application          | MergeBindings                   |                                                                  |
-| Application          | ResolveUnitErrors               |                                                                  |
-| Application          | ScaleApplications               |                                                                  |
-| Application          | SetCharm                        | `PATCH /application/{name}`                                      |
-| Application          | SetConfigs                      |                                                                  |
-| Application          | SetConstraints                  |                                                                  |
-| Application          | SetMetricCredentials            |                                                                  |
-| Application          | SetRelationsSuspended           |                                                                  |
-| Application          | Unexpose                        |                                                                  |
-| Application          | UnitsInfo                       |                                                                  |
-| Application          | UnsetApplicationsConfig         |                                                                  |
-| Application          | UpdateApplicationBase           |                                                                  |
-| ApplicationOffers    | ApplicationOffers               |                                                                  |
-| ApplicationOffers    | DestroyOffers                   |                                                                  |
-| ApplicationOffers    | FindApplicationOffers           |                                                                  |
-| ApplicationOffers    | GetConsumeDetails               |                                                                  |
-| ApplicationOffers    | ListApplicationOffers           |                                                                  |
-| ApplicationOffers    | ModifyOfferAccess               |                                                                  |
-| ApplicationOffers    | Offer                           |                                                                  |
-| ApplicationOffers    | RemoteApplicationInfo           |                                                                  |
-| Backup               | Create                          |                                                                  |
-| Block                | List                            |                                                                  |
-| Block                | SwitchBlockOff                  |                                                                  |
-| Block                | SwitchBlockOn                   |                                                                  |
-| Bundle               | ExportBundle                    |                                                                  |
-| Bundle               | GetChanges                      |                                                                  |
-| Bundle               | GetChangesMapArgs               |                                                                  |
-| Charms               | AddCharm                        |                                                                  |
-| Charms               | CharmInfo                       |                                                                  |
-| Charms               | CheckCharmPlacement             |                                                                  |
-| Charms               | GetDownloadInfos                |                                                                  |
-| Charms               | IsMetered                       |                                                                  |
-| Charms               | List                            |                                                                  |
-| Charms               | ListCharmResources              |                                                                  |
-| Charms               | ResolveCharms                   |                                                                  |
-| Client               | FindTools                       |                                                                  |
-| Client               | FullStatus                      |                                                                  |
-| Client               | StatusHistory                   |                                                                  |
-| Client               | WatchAll                        |                                                                  |
-| Cloud                | AddCloud                        | `POST /clouds`                                                   |
-| Cloud                | AddCredentials                  |                                                                  |
-| Cloud                | CheckCredentialsModels          |                                                                  |
-| Cloud                | Cloud                           | `GET /cloud/{name}`                                              |
-| Cloud                | CloudInfo                       | `GET /cloud/{name}`                                              |
-| Cloud                | Clouds                          | `GET /clouds/supported`                                          |
-| Cloud                | Credential                      |                                                                  |
-| Cloud                | CredentialContents              |                                                                  |
-| Cloud                | InstanceTypes                   |                                                                  |
-| Cloud                | ListCloudInfo                   | `GET /clouds`                                                    |
-| Cloud                | ModifyCloudAccess               | `PATCH /cloud/{name}/access`                                     |
-| Cloud                | RemoveClouds                    | `DELETE /cloud/{name}`                                           |
-| Cloud                | RevokeCredentialsCheckModels    |                                                                  |
-| Cloud                | UpdateCloud                     |                                                                  |
-| Cloud                | UpdateCredentialsCheckModels    |                                                                  |
-| Cloud                | UserCredentials                 |                                                                  |
-| Controller           | AllModels                       |                                                                  |
-| Controller           | CloudSpec                       |                                                                  |
-| Controller           | ConfigSet                       |                                                                  |
-| Controller           | ControllerAPIInfoForModels      |                                                                  |
-| Controller           | ControllerConfig                |                                                                  |
-| Controller           | ControllerVersion               |                                                                  |
-| Controller           | DashboardConnectionInfo         |                                                                  |
-| Controller           | DestroyController               |                                                                  |
-| Controller           | GetCloudSpec                    |                                                                  |
-| Controller           | GetControllerAccess             |                                                                  |
-| Controller           | HostedModelConfigs              |                                                                  |
-| Controller           | IdentityProviderURL             |                                                                  |
-| Controller           | InitiateMigration               |                                                                  |
-| Controller           | ListBlockedModels               |                                                                  |
-| Controller           | ModelConfig                     |                                                                  |
-| Controller           | ModelStatus                     |                                                                  |
-| Controller           | ModifyControllerAccess          |                                                                  |
-| Controller           | MongoVersion                    |                                                                  |
-| Controller           | RemoveBlocks                    |                                                                  |
-| Controller           | WatchAllModelSummaries          |                                                                  |
-| Controller           | WatchAllModels                  |                                                                  |
-| Controller           | WatchCloudSpecsChanges          |                                                                  |
-| Controller           | WatchModelSummaries             |                                                                  |
-| CredentialManager    | InvalidateModelCredential       |                                                                  |
-| FirewallRules        | ListFirewallRules               |                                                                  |
-| FirewallRules        | SetFirewallRules                |                                                                  |
-| HighAvailability     | EnableHA                        |                                                                  |
-| ImageMetaDataManager | Delete                          |                                                                  |
-| ImageMetaDataManager | List                            |                                                                  |
-| ImageMetaDataManager | Save                            |                                                                  |
-| KeyManager           | AddKeys                         |                                                                  |
-| KeyManager           | DeleteKeys                      |                                                                  |
-| KeyManager           | ImportKeys                      |                                                                  |
-| KeyManager           | ListKeys                        |                                                                  |
-| MachineManager       | AddMachines                     |                                                                  |
-| MachineManager       | DestroyMachineWithParams        |                                                                  |
-| MachineManager       | GetUpgradeSeriesMessages        |                                                                  |
-| MachineManager       | InstanceTypes                   |                                                                  |
-| MachineManager       | ProvisioningScript              |                                                                  |
-| MachineManager       | RetryProvisioning               |                                                                  |
-| MachineManager       | UpgradeSeriesComplete           |                                                                  |
-| MachineManager       | UpgradeSeriesPrepare            |                                                                  |
-| MachineManager       | UpgradeSeriesValidate           |                                                                  |
-| MachineManager       | WatchUpgradeSeriesNotifications |                                                                  |
-| MetricsDebug         | GetMetrics                      |                                                                  |
-| MetricsDebug         | SetMeterStatus                  |                                                                  |
-| ModelConfig          | GetModelConstraints             |                                                                  |
-| ModelConfig          | ModelGet                        |                                                                  |
-| ModelConfig          | ModelSet                        |                                                                  |
-| ModelConfig          | ModelUnset                      |                                                                  |
-| ModelConfig          | SLALevel                        |                                                                  |
-| ModelConfig          | Sequences                       |                                                                  |
-| ModelConfig          | SetModelConstraints             |                                                                  |
-| ModelConfig          | SetSLALevel                     |                                                                  |
-| ModelGeneration      | AbortBranch                     |                                                                  |
-| ModelGeneration      | AddBranch                       |                                                                  |
-| ModelGeneration      | BranchInfo                      |                                                                  |
-| ModelGeneration      | CommitBranch                    |                                                                  |
-| ModelGeneration      | HasActiveBranch                 |                                                                  |
-| ModelGeneration      | ListCommits                     |                                                                  |
-| ModelGeneration      | ShowCommit                      |                                                                  |
-| ModelGeneration      | TrackBranch                     |                                                                  |
-| ModelManager         | ChangeModelCredential           | `PATCH /model/{name}/credential`                                 |
-| ModelManager         | CreateModel                     | `POST /models`                                                   |
-| ModelManager         | DestroyModels                   | `DELETE /model/{name}`                                           |
-| ModelManager         | DumpModels                      | `GET /models?detailed=true&all=true`                             |
-| ModelManager         | DumpModelsDB                    | N/A                                                              |
-| ModelManager         | ListModelSummaries              | `GET /models?detailed=true`                                      |
-| ModelManager         | ListModels                      | `GET /models`                                                    |
-| ModelManager         | ModelDefaultsForClouds          | `GET /models/defaults`                                           |
-| ModelManager         | ModelInfo                       | `GET /model/{name}`                                              |
-| ModelManager         | ModelStatus                     | `GET /model/{name}/status`                                       |
-| ModelManager         | ModifyModelAccess               | `PATCH /model/{name}/access`                                     |
-| ModelManager         | SetModelDefaults                | `PATCH /models/defaults`                                         |
-| ModelManager         | UnsetModelDefaults              | `PATCH /models/defaults`                                         |
-| ModelUpgrader        | AbortModelUpgrade               |                                                                  |
-| ModelUpgrader        | UpgradeModel                    |                                                                  |
-| Payloads             | List                            |                                                                  |
-| Pinger               | Ping                            |                                                                  |
-| Pinger               | Stop                            |                                                                  |
-| Resources            | AddPendingResources             |                                                                  |
-| Resources            | ListResources                   |                                                                  |
-| SSHClient            | AllAddresses                    |                                                                  |
-| SSHClient            | ModelCredentialForSSH           |                                                                  |
-| SSHClient            | PrivateAddress                  |                                                                  |
-| SSHClient            | Proxy                           |                                                                  |
-| SSHClient            | PublicAddress                   |                                                                  |
-| SSHClient            | PublicKeys                      |                                                                  |
-| SecretBackends       | AddSecretBackends               |                                                                  |
-| SecretBackends       | ListSecretBackends              |                                                                  |
-| SecretBackends       | RemoveSecretBackends            |                                                                  |
-| SecretBackends       | UpdateSecretBackends            |                                                                  |
-| Secrets              | ListSecrets                     |                                                                  |
-| Spaces               | CreateSpaces                    |                                                                  |
-| Spaces               | ListSpaces                      |                                                                  |
-| Spaces               | MoveSubnets                     |                                                                  |
-| Spaces               | ReloadSpaces                    |                                                                  |
-| Spaces               | RemoveSpace                     |                                                                  |
-| Spaces               | RenameSpace                     |                                                                  |
-| Spaces               | ShowSpace                       |                                                                  |
-| Storage              | AddToUnit                       |                                                                  |
-| Storage              | Attach                          |                                                                  |
-| Storage              | CreatePool                      |                                                                  |
-| Storage              | DetachStorage                   |                                                                  |
-| Storage              | Import                          |                                                                  |
-| Storage              | ListFilesystems                 |                                                                  |
-| Storage              | ListPools                       |                                                                  |
-| Storage              | ListStorageDetails              |                                                                  |
-| Storage              | ListVolumes                     |                                                                  |
-| Storage              | Remove                          |                                                                  |
-| Storage              | RemovePool                      |                                                                  |
-| Storage              | StorageDetails                  |                                                                  |
-| Storage              | UpdatePool                      |                                                                  |
-| Subnets              | AllZones                        |                                                                  |
-| Subnets              | ListSubnets                     |                                                                  |
-| Subnets              | SubnetsByCIDR                   |                                                                  |
-| UserManager          | AddUser                         | `POST /users`                                                    |
-| UserManager          | DisableUser                     | `PATCH /user/{name}`                                             |
-| UserManager          | EnableUser                      | `PATCH /user/{name}`                                             |
-| UserManager          | ModelUserInfo                   | `GET /models?user={name}`                                        |
-| UserManager          | RemoveUser                      | `DELETE /user/{name}`                                            |
-| UserManager          | ResetPassword                   | `PATCH /user/{name}`                                             |
-| UserManager          | SetPassword                     | `PATCH /user/{name}`                                             |
-| UserManager          | UserInfo                        | `GET /user/{name}`                                               |
+| Facade               | Facade Call                     | API Path                                                                |
+| :------------------- | :------------------------------ | :---------------------------------------------------------------------- |
+| Action               | Actions                         |                                                                         |
+| Action               | ApplicationsCharmsActions       |                                                                         |
+| Action               | Cancel                          |                                                                         |
+| Action               | EnqueueOperation                |                                                                         |
+| Action               | ListOperations                  |                                                                         |
+| Action               | Operations                      |                                                                         |
+| Action               | Run                             |                                                                         |
+| Action               | RunOnAllMachines                |                                                                         |
+| Action               | WatchActionsProgress            |                                                                         |
+| Admin                | Login                           |                                                                         |
+| Admin                | RedirectInfo                    |                                                                         |
+| AllModelWatcher      | Next                            |                                                                         |
+| AllModelWatcher      | Stop                            |                                                                         |
+| AllWatcher           | Next                            |                                                                         |
+| AllWatcher           | Stop                            |                                                                         |
+| Annotations          | Get                             |                                                                         |
+| Annotations          | Set                             |                                                                         |
+| Application          | AddRelation                     | `POST /application/relate`                                              |
+| Application          | AddUnits                        |                                                                         |
+| Application          | ApplicationsInfo                | `GET /application/{application}`                                        |
+| Application          | CharmConfig                     |                                                                         |
+| Application          | CharmRelations                  |                                                                         |
+| Application          | Consume                         |                                                                         |
+| Application          | Deploy                          |                                                                         |
+| Application          | DeployFromRepository            | `POST /application/{application}?force=false&dry-run=false&trust=false` |
+| Application          | DestroyApplication              | `DELETE /application/{application}`                                     |
+| Application          | DestroyConsumedApplications     |                                                                         |
+| Application          | DestroyRelation                 |                                                                         |
+| Application          | DestroyUnit                     |                                                                         |
+| Application          | Expose                          |                                                                         |
+| Application          | Get                             |                                                                         |
+| Application          | GetCharmURLOrigin               |                                                                         |
+| Application          | GetConfig                       |                                                                         |
+| Application          | GetConstraints                  |                                                                         |
+| Application          | Leader                          |                                                                         |
+| Application          | MergeBindings                   |                                                                         |
+| Application          | ResolveUnitErrors               |                                                                         |
+| Application          | ScaleApplications               |                                                                         |
+| Application          | SetCharm                        | `PATCH /application/{application}`                                      |
+| Application          | SetConfigs                      |                                                                         |
+| Application          | SetConstraints                  |                                                                         |
+| Application          | SetMetricCredentials            |                                                                         |
+| Application          | SetRelationsSuspended           |                                                                         |
+| Application          | Unexpose                        |                                                                         |
+| Application          | UnitsInfo                       |                                                                         |
+| Application          | UnsetApplicationsConfig         |                                                                         |
+| Application          | UpdateApplicationBase           |                                                                         |
+| ApplicationOffers    | ApplicationOffers               |                                                                         |
+| ApplicationOffers    | DestroyOffers                   |                                                                         |
+| ApplicationOffers    | FindApplicationOffers           |                                                                         |
+| ApplicationOffers    | GetConsumeDetails               |                                                                         |
+| ApplicationOffers    | ListApplicationOffers           |                                                                         |
+| ApplicationOffers    | ModifyOfferAccess               |                                                                         |
+| ApplicationOffers    | Offer                           |                                                                         |
+| ApplicationOffers    | RemoteApplicationInfo           |                                                                         |
+| Backup               | Create                          |                                                                         |
+| Block                | List                            |                                                                         |
+| Block                | SwitchBlockOff                  |                                                                         |
+| Block                | SwitchBlockOn                   |                                                                         |
+| Bundle               | ExportBundle                    |                                                                         |
+| Bundle               | GetChanges                      |                                                                         |
+| Bundle               | GetChangesMapArgs               |                                                                         |
+| Charms               | AddCharm                        |                                                                         |
+| Charms               | CharmInfo                       |                                                                         |
+| Charms               | CheckCharmPlacement             |                                                                         |
+| Charms               | GetDownloadInfos                |                                                                         |
+| Charms               | IsMetered                       |                                                                         |
+| Charms               | List                            |                                                                         |
+| Charms               | ListCharmResources              |                                                                         |
+| Charms               | ResolveCharms                   |                                                                         |
+| Client               | FindTools                       |                                                                         |
+| Client               | FullStatus                      |                                                                         |
+| Client               | StatusHistory                   |                                                                         |
+| Client               | WatchAll                        |                                                                         |
+| Cloud                | AddCloud                        | `POST /clouds`                                                          |
+| Cloud                | AddCredentials                  |                                                                         |
+| Cloud                | CheckCredentialsModels          |                                                                         |
+| Cloud                | Cloud                           | `GET /cloud/{cloud}`                                                    |
+| Cloud                | CloudInfo                       | `GET /cloud/{cloud}`                                                    |
+| Cloud                | Clouds                          | `GET /clouds/supported`                                                 |
+| Cloud                | Credential                      |                                                                         |
+| Cloud                | CredentialContents              |                                                                         |
+| Cloud                | InstanceTypes                   |                                                                         |
+| Cloud                | ListCloudInfo                   | `GET /clouds`                                                           |
+| Cloud                | ModifyCloudAccess               | `PATCH /cloud/{cloud}/access`                                           |
+| Cloud                | RemoveClouds                    | `DELETE /cloud/{cloud}`                                                 |
+| Cloud                | RevokeCredentialsCheckModels    |                                                                         |
+| Cloud                | UpdateCloud                     |                                                                         |
+| Cloud                | UpdateCredentialsCheckModels    |                                                                         |
+| Cloud                | UserCredentials                 |                                                                         |
+| Controller           | AllModels                       |                                                                         |
+| Controller           | CloudSpec                       |                                                                         |
+| Controller           | ConfigSet                       |                                                                         |
+| Controller           | ControllerAPIInfoForModels      |                                                                         |
+| Controller           | ControllerConfig                |                                                                         |
+| Controller           | ControllerVersion               |                                                                         |
+| Controller           | DashboardConnectionInfo         |                                                                         |
+| Controller           | DestroyController               |                                                                         |
+| Controller           | GetCloudSpec                    |                                                                         |
+| Controller           | GetControllerAccess             |                                                                         |
+| Controller           | HostedModelConfigs              |                                                                         |
+| Controller           | IdentityProviderURL             |                                                                         |
+| Controller           | InitiateMigration               |                                                                         |
+| Controller           | ListBlockedModels               |                                                                         |
+| Controller           | ModelConfig                     |                                                                         |
+| Controller           | ModelStatus                     |                                                                         |
+| Controller           | ModifyControllerAccess          |                                                                         |
+| Controller           | MongoVersion                    |                                                                         |
+| Controller           | RemoveBlocks                    |                                                                         |
+| Controller           | WatchAllModelSummaries          |                                                                         |
+| Controller           | WatchAllModels                  |                                                                         |
+| Controller           | WatchCloudSpecsChanges          |                                                                         |
+| Controller           | WatchModelSummaries             |                                                                         |
+| CredentialManager    | InvalidateModelCredential       |                                                                         |
+| FirewallRules        | ListFirewallRules               |                                                                         |
+| FirewallRules        | SetFirewallRules                |                                                                         |
+| HighAvailability     | EnableHA                        |                                                                         |
+| ImageMetaDataManager | Delete                          |                                                                         |
+| ImageMetaDataManager | List                            |                                                                         |
+| ImageMetaDataManager | Save                            |                                                                         |
+| KeyManager           | AddKeys                         |                                                                         |
+| KeyManager           | DeleteKeys                      |                                                                         |
+| KeyManager           | ImportKeys                      |                                                                         |
+| KeyManager           | ListKeys                        |                                                                         |
+| MachineManager       | AddMachines                     |                                                                         |
+| MachineManager       | DestroyMachineWithParams        |                                                                         |
+| MachineManager       | GetUpgradeSeriesMessages        |                                                                         |
+| MachineManager       | InstanceTypes                   |                                                                         |
+| MachineManager       | ProvisioningScript              |                                                                         |
+| MachineManager       | RetryProvisioning               |                                                                         |
+| MachineManager       | UpgradeSeriesComplete           |                                                                         |
+| MachineManager       | UpgradeSeriesPrepare            |                                                                         |
+| MachineManager       | UpgradeSeriesValidate           |                                                                         |
+| MachineManager       | WatchUpgradeSeriesNotifications |                                                                         |
+| MetricsDebug         | GetMetrics                      |                                                                         |
+| MetricsDebug         | SetMeterStatus                  |                                                                         |
+| ModelConfig          | GetModelConstraints             |                                                                         |
+| ModelConfig          | ModelGet                        |                                                                         |
+| ModelConfig          | ModelSet                        |                                                                         |
+| ModelConfig          | ModelUnset                      |                                                                         |
+| ModelConfig          | SLALevel                        |                                                                         |
+| ModelConfig          | Sequences                       |                                                                         |
+| ModelConfig          | SetModelConstraints             |                                                                         |
+| ModelConfig          | SetSLALevel                     |                                                                         |
+| ModelGeneration      | AbortBranch                     |                                                                         |
+| ModelGeneration      | AddBranch                       |                                                                         |
+| ModelGeneration      | BranchInfo                      |                                                                         |
+| ModelGeneration      | CommitBranch                    |                                                                         |
+| ModelGeneration      | HasActiveBranch                 |                                                                         |
+| ModelGeneration      | ListCommits                     |                                                                         |
+| ModelGeneration      | ShowCommit                      |                                                                         |
+| ModelGeneration      | TrackBranch                     |                                                                         |
+| ModelManager         | ChangeModelCredential           | `PATCH /model/{model}/credential`                                       |
+| ModelManager         | CreateModel                     | `POST /models`                                                          |
+| ModelManager         | DestroyModels                   | `DELETE /model/{model}`                                                 |
+| ModelManager         | DumpModels                      | `GET /models?detailed=true&all=true`                                    |
+| ModelManager         | DumpModelsDB                    | N/A                                                                     |
+| ModelManager         | ListModelSummaries              | `GET /models?detailed=true`                                             |
+| ModelManager         | ListModels                      | `GET /models`                                                           |
+| ModelManager         | ModelDefaultsForClouds          | `GET /models/defaults`                                                  |
+| ModelManager         | ModelInfo                       | `GET /model/{model}`                                                    |
+| ModelManager         | ModelStatus                     | `GET /model/{model}/status`                                             |
+| ModelManager         | ModifyModelAccess               | `PATCH /model/{model}/access`                                           |
+| ModelManager         | SetModelDefaults                | `PATCH /models/defaults`                                                |
+| ModelManager         | UnsetModelDefaults              | `PATCH /models/defaults`                                                |
+| ModelUpgrader        | AbortModelUpgrade               |                                                                         |
+| ModelUpgrader        | UpgradeModel                    |                                                                         |
+| Payloads             | List                            |                                                                         |
+| Pinger               | Ping                            |                                                                         |
+| Pinger               | Stop                            |                                                                         |
+| Resources            | AddPendingResources             |                                                                         |
+| Resources            | ListResources                   |                                                                         |
+| SSHClient            | AllAddresses                    |                                                                         |
+| SSHClient            | ModelCredentialForSSH           |                                                                         |
+| SSHClient            | PrivateAddress                  |                                                                         |
+| SSHClient            | Proxy                           |                                                                         |
+| SSHClient            | PublicAddress                   |                                                                         |
+| SSHClient            | PublicKeys                      |                                                                         |
+| SecretBackends       | AddSecretBackends               |                                                                         |
+| SecretBackends       | ListSecretBackends              |                                                                         |
+| SecretBackends       | RemoveSecretBackends            |                                                                         |
+| SecretBackends       | UpdateSecretBackends            |                                                                         |
+| Secrets              | ListSecrets                     |                                                                         |
+| Spaces               | CreateSpaces                    |                                                                         |
+| Spaces               | ListSpaces                      |                                                                         |
+| Spaces               | MoveSubnets                     |                                                                         |
+| Spaces               | ReloadSpaces                    |                                                                         |
+| Spaces               | RemoveSpace                     |                                                                         |
+| Spaces               | RenameSpace                     |                                                                         |
+| Spaces               | ShowSpace                       |                                                                         |
+| Storage              | AddToUnit                       |                                                                         |
+| Storage              | Attach                          |                                                                         |
+| Storage              | CreatePool                      |                                                                         |
+| Storage              | DetachStorage                   |                                                                         |
+| Storage              | Import                          |                                                                         |
+| Storage              | ListFilesystems                 |                                                                         |
+| Storage              | ListPools                       |                                                                         |
+| Storage              | ListStorageDetails              |                                                                         |
+| Storage              | ListVolumes                     |                                                                         |
+| Storage              | Remove                          |                                                                         |
+| Storage              | RemovePool                      |                                                                         |
+| Storage              | StorageDetails                  |                                                                         |
+| Storage              | UpdatePool                      |                                                                         |
+| Subnets              | AllZones                        |                                                                         |
+| Subnets              | ListSubnets                     |                                                                         |
+| Subnets              | SubnetsByCIDR                   |                                                                         |
+| UserManager          | AddUser                         | `POST /users`                                                           |
+| UserManager          | DisableUser                     | `PATCH /user/{user}`                                                    |
+| UserManager          | EnableUser                      | `PATCH /user/{user}`                                                    |
+| UserManager          | ModelUserInfo                   | `GET /models?user={user}`                                               |
+| UserManager          | RemoveUser                      | `DELETE /user/{user}`                                                   |
+| UserManager          | ResetPassword                   | `PATCH /user/{user}`                                                    |
+| UserManager          | SetPassword                     | `PATCH /user/{user}`                                                    |
+| UserManager          | UserInfo                        | `GET /user/{user}`                                                      |

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ This table tracks progress through the redesign of the Juju client API:
 | Application          | MergeBindings                   |                                                                                              |
 | Application          | ResolveUnitErrors               |                                                                                              |
 | Application          | ScaleApplications               |                                                                                              |
-| Application          | SetCharm                        | `PATCH /model/{model}/application/{application}/refresh`                                     |
+| Application          | SetCharm                        | `PATCH /model/{model}/application/{application}/refresh?force=false&dry-run=false`           |
 | Application          | SetConfigs                      |                                                                                              |
 | Application          | SetConstraints                  |                                                                                              |
 | Application          | SetMetricCredentials            |                                                                                              |

--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ This table tracks progress through the redesign of the Juju client API:
 | Annotations          | Set                             |                                                                                              |
 | Application          | AddRelation                     | `POST /integrate`                                                                            |
 | Application          | AddUnits                        |                                                                                              |
-| Application          | ApplicationsInfo                | `GET /model{model}/application/{application}`                                                |
+| Application          | ApplicationsInfo                | `GET /model/{model}/application/{application}`                                                |
 | Application          | CharmConfig                     |                                                                                              |
 | Application          | CharmRelations                  |                                                                                              |
 | Application          | Consume                         |                                                                                              |
 | Application          | Deploy                          |                                                                                              |
-| Application          | DeployFromRepository            | `POST /model/{model}/application/{application}/deploy?force=false&dry-run=false&trust=false` |
-| Application          | DestroyApplication              | `DELETE /model/{model}/application/{application}`                                            |
+| Application          | DeployFromRepository            | `POST /model/{model}/application/{application}/deploy&dry-run=false&trust=false` |
+| Application          | DestroyApplication              | `DELETE /model/{model}/application/{application}?force=false`                                            |
 | Application          | DestroyConsumedApplications     |                                                                                              |
 | Application          | DestroyRelation                 |                                                                                              |
 | Application          | DestroyUnit                     |                                                                                              |

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -45,6 +45,126 @@ tags:
       description: Find out more about Juju clouds.
       url: https://juju.is/docs/olm/manage-clouds
 paths:
+  /application/{name}:
+    get:
+      tags:
+        - application
+      description: Returns application information.
+      operationId: getApplication
+      parameters:
+        - $ref: "#/components/parameters/ApplicationName"
+      responses:
+        "200":
+          description: Detailed information about the requested application.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Application"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+    post:
+      tags:
+        - application
+      description: Is a one-stop deployment method for repository charms. Only a charm
+        name is required to deploy. If argument validation fails, a list of all errors
+        found in validation will be returned. If a local resource is provided, details
+        required for uploading the validated resource will be returned.
+      operationId: addApplication
+      parameters:
+        - $ref: "#/components/parameters/ApplicationName"
+        - $ref: "#/components/parameters/Force"
+        - $ref: "#/components/parameters/DryRun"
+        - $ref: "#/components/parameters/Trust"
+        - $ref: "#/components/parameters/NumUnits"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeployFromRepositoryArgs'
+        required: true
+      responses:
+        "200":
+          description: Detailed information about the requested application.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeployFromRepositoryResult"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+    delete:
+      tags:
+        - application
+      description: Removes a given application.
+      operationId: deleteApplication
+      parameters:
+        - $ref: "#/components/parameters/ApplicationName"
+        - $ref: "#/components/parameters/DestroyStorage"
+        - $ref: "#/components/parameters/Force"
+        - $ref: "#/components/parameters/MaxWait"
+        - $ref: "#/components/parameters/DryRun"
+      responses:
+        "200":
+          $ref: "#/components/responses/ApplicationDestroyed"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /application/{name}/refresh:
+    patch:
+      tags:
+        - application
+      description: Sets the charm for a given for the application.
+      operationId: refreshApplication
+      parameters:
+        - $ref: "#/components/parameters/ApplicationName"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApplicationSetCharm'
+        required: true
+      responses:
+        "200":
+          $ref: "#/components/responses/EmptySyncResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /application/relate:
+    post:
+      tags:
+        - application
+      summary: Adds a relation.
+      description: Adds a relation between the specified endpoints and returns the
+        relation info.
+      operationId: relateApplication
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddRelationArgs'
+        required: true
+      responses:
+        "200":
+          $ref: "#/components/responses/RelationCreated"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
   /cloud/{name}:
     get:
       tags:
@@ -471,6 +591,173 @@ paths:
           $ref: "#/components/responses/InternalServerError"
 components:
   schemas:
+    AddRelationArgs:
+      type: object
+      properties:
+        endpoints:
+          type: array
+          items:
+            type: string
+        via-cidrs:
+          type: array
+          items:
+            type: string
+      additionalProperties: false
+      required:
+        - endpoints
+    Application:
+      type: object
+      description: Information about a given application.
+      properties:
+        base:
+          $ref: '#/components/schemas/Base'
+        channel:
+          type: string
+        charm:
+          type: string
+        constraints:
+          $ref: '#/components/schemas/Constraints'
+        endpoint-bindings:
+          type: object
+          patternProperties:
+            .*:
+              type: string
+        exposed:
+          type: boolean
+        exposed-endpoints:
+          type: object
+          patternProperties:
+            .*:
+              $ref: '#/components/schemas/ExposedEndpoint'
+        life:
+          type: string
+        principal:
+          type: boolean
+        remote:
+          type: boolean
+        tag:
+          type: string
+      additionalProperties: false
+      required:
+        - tag
+        - principal
+        - exposed
+        - remote
+        - life
+    ApplicationSetCharm:
+      type: object
+      properties:
+        application:
+          type: string
+        channel:
+          type: string
+        charm-origin:
+          $ref: '#/components/schemas/CharmOrigin'
+        charm-url:
+          type: string
+        config-settings:
+          type: object
+          patternProperties:
+            .*:
+              type: string
+        config-settings-yaml:
+          type: string
+        endpoint-bindings:
+          type: object
+          patternProperties:
+            .*:
+              type: string
+        force:
+          type: boolean
+        force-base:
+          type: boolean
+        force-units:
+          type: boolean
+        generation:
+          type: string
+        resource-ids:
+          type: object
+          patternProperties:
+            .*:
+              type: string
+        storage-constraints:
+          type: object
+          patternProperties:
+            .*:
+              $ref: '#/components/schemas/StorageConstraints'
+      additionalProperties: false
+      required:
+        - application
+        - generation
+        - charm-url
+        - channel
+        - force
+        - force-units
+        - force-base
+    Base:
+      type: object
+      properties:
+        channel:
+          type: string
+        name:
+          type: string
+      additionalProperties: false
+      required:
+        - name
+        - channel
+    CharmRelation:
+      type: object
+      properties:
+        interface:
+          type: string
+        limit:
+          type: integer
+        name:
+          type: string
+        optional:
+          type: boolean
+        role:
+          type: string
+        scope:
+          type: string
+      additionalProperties: false
+      required:
+        - name
+        - role
+        - interface
+        - optional
+        - limit
+        - scope
+    CharmOrigin:
+      type: object
+      properties:
+        architecture:
+          type: string
+        base:
+          $ref: '#/components/schemas/Base'
+        branch:
+          type: string
+        hash:
+          type: string
+        id:
+          type: string
+        instance-key:
+          type: string
+        revision:
+          type: integer
+        risk:
+          type: string
+        source:
+          type: string
+        track:
+          type: string
+        type:
+          type: string
+      additionalProperties: false
+      required:
+        - source
+        - type
+        - id
     Cloud:
       type: object
       properties:
@@ -626,6 +913,140 @@ components:
       additionalProperties: false
       required:
         - permissions
+    Constraints:
+      type: object
+      properties:
+        allocate-public-ip:
+          type: boolean
+        arch:
+          type: string
+        container:
+          type: string
+        cores:
+          type: integer
+        cpu-power:
+          type: integer
+        image-id:
+          type: string
+        instance-role:
+          type: string
+        instance-type:
+          type: string
+        mem:
+          type: integer
+        root-disk:
+          type: integer
+        root-disk-source:
+          type: string
+        spaces:
+          type: array
+          items:
+            type: string
+        tags:
+          type: array
+          items:
+            type: string
+        virt-type:
+          type: string
+        zones:
+          type: array
+          items:
+            type: string
+      additionalProperties: false
+    DeployFromRepositoryArgs:
+      type: object
+      properties:
+        AttachStorage:
+          type: array
+          items:
+            type: string
+        CharmName:
+          type: string
+        ConfigYAML:
+          type: string
+        Cons:
+          $ref: '#/components/schemas/Constraints'
+        Devices:
+          type: object
+          patternProperties:
+            .*:
+              $ref: '#/components/schemas/Constraints'
+        Placement:
+          type: array
+          items:
+            $ref: '#/components/schemas/Placement'
+        Storage:
+          type: object
+          patternProperties:
+            .*:
+              $ref: '#/components/schemas/Constraints'
+        base:
+          $ref: '#/components/schemas/Base'
+        channel:
+          type: string
+        endpoint-bindings:
+          type: object
+          patternProperties:
+            .*:
+              type: string
+        resources:
+          type: object
+          patternProperties:
+            .*:
+              type: string
+        revision:
+          type: integer
+      additionalProperties: false
+      required:
+        - CharmName
+    DeployFromRepositoryInfo:
+      type: object
+      properties:
+        architecture:
+          type: string
+        base:
+          $ref: '#/components/schemas/Base'
+        channel:
+          type: string
+        charm-url:
+          type: string
+        effective-channel:
+          type: string
+      additionalProperties: false
+      required:
+        - charm-url
+        - architecture
+    DeployFromRepositoryResult:
+      type: object
+      properties:
+        Info:
+          $ref: '#/components/schemas/DeployFromRepositoryInfo'
+        PendingResourceUploads:
+          type: array
+          items:
+            $ref: '#/components/schemas/PendingResourceUpload'
+      additionalProperties: false
+      required:
+        - Info
+        - PendingResourceUploads
+    PendingResourceUpload:
+      type: object
+      description: Information about the local resources that need to be uploaded by the client after a deploy operation.
+      properties:
+        Filename:
+          type: string
+        Name:
+          type: string
+        Type:
+          type: string
+        pending-id:
+          type: string
+      additionalProperties: false
+      required:
+        - Name
+        - Filename
+        - pending-id
+        - Type
     Error:
       type: object
       properties:
@@ -643,6 +1064,18 @@ components:
         - error
         - error_code
         - type
+    ExposedEndpoint:
+      type: object
+      properties:
+        expose-to-cidrs:
+          type: array
+          items:
+            type: string
+        expose-to-spaces:
+          type: array
+          items:
+            type: string
+      additionalProperties: false
     MachineHardware:
       type: object
       properties:
@@ -1037,6 +1470,17 @@ components:
       description: Represents a volume within the model
       allOf:
         - $ref: "#/components/schemas/ModelStorageAttributes"
+    Placement:
+      type: object
+      properties:
+        directive:
+          type: string
+        scope:
+          type: string
+      additionalProperties: false
+      required:
+        - scope
+        - directive
     RegionDefaults:
       type: object
       properties:
@@ -1066,6 +1510,29 @@ components:
         - name
         - backend-type
         - config
+    StorageConstraints:
+      type: object
+      properties:
+        count:
+          type: integer
+        pool:
+          type: string
+        size:
+          type: integer
+      additionalProperties: false
+    Success:
+      type: object
+      properties:
+        status:
+          type: string
+          example: Success.
+        status_code:
+          type: integer
+          example: 200
+        type:
+          type: string
+          example: sync
+      additionalProperties: false
     SupportedFeature:
       type: object
       properties:
@@ -1111,6 +1578,13 @@ components:
         enum:
           - true
           - false
+    ApplicationName:
+      in: path
+      name: name
+      required: true
+      description: The name of a deployed application.
+      schema:
+        type: string
     CloudName:
       in: path
       name: name
@@ -1135,6 +1609,12 @@ components:
         enum:
           - true
           - false
+    DryRun:
+      in: query
+      name: dry-run
+      required: false
+      schema:
+        type: boolean
     Force:
       in: query
       name: force
@@ -1154,12 +1634,24 @@ components:
       description: The name of a model in the controller.
       schema:
         type: string
+    NumUnits:
+      in: query
+      name: num-units
+      required: false
+      schema:
+        type: integer
     Timeout:
       in: query
       name: max-wait
       required: false
       schema:
         type: integer
+    Trust:
+      in: query
+      name: trust
+      required: false
+      schema:
+        type: boolean
     User:
       in: query
       name: user
@@ -1168,6 +1660,22 @@ components:
       schema:
         type: string
   responses:
+    ApplicationDestroyed:
+      type: object
+      properties:
+        destroyed-storage:
+          type: array
+          items:
+            type: string
+        destroyed-units:
+          type: array
+          items:
+            type: string
+        detached-storage:
+          type: array
+          items:
+            type: string
+      additionalProperties: false
     BadRequest:
       description: Bad request.
       content:
@@ -1179,31 +1687,13 @@ components:
       content:
         application/json:
           schema:
-            properties:
-              status:
-                example: Success
-                type: string
-              status_code:
-                example: 200
-                type: integer
-              type:
-                example: sync
-                type: string
+            $ref: '#/components/schemas/Success'
     EntityCreated:
       description: Entity created response
       content:
         application/json:
           schema:
-            properties:
-              status:
-                example: Success
-                type: string
-              status_code:
-                example: 200
-                type: integer
-              type:
-                example: sync
-                type: string
+            $ref: '#/components/schemas/Success'
       headers:
         Location:
           schema:
@@ -1222,6 +1712,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
+    RelationCreated:
+      description: Relation added between specified endpoints.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/CharmRelation'
 # Use this section to define reusable objects
 # callbacks: {}
 # examples: {}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -618,6 +618,8 @@ components:
           $ref: '#/components/schemas/Base'
         channel:
           $ref: '#/components/schemas/CharmChannel'
+        charm-origin:
+          $ref: '#/components/schemas/CharmOrigin'
         charm:
           type: string
         constraints:
@@ -632,14 +634,8 @@ components:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ExposedEndpoint'
-        life:
-          type: string
         principal:
           type: boolean
-        remote:
-          type: boolean
-        tag:
-          type: string
       additionalProperties: false
       required:
         - tag

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -727,6 +727,10 @@ components:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/ExposedEndpoint'
+        resources:
+          type: array
+          items:
+            $ref: '#/components/schemas/Resource'
         principal:
           type: boolean
       additionalProperties: false
@@ -1091,24 +1095,6 @@ components:
       required:
         - charm-name
         - model
-    PendingResourceUpload:
-      type: object
-      description: Information about the local resources that need to be uploaded by the client after a deploy operation.
-      properties:
-        filename:
-          type: string
-        name:
-          type: string
-        type:
-          type: string
-        pending-id:
-          type: string
-      additionalProperties: false
-      required:
-        - Name
-        - Filename
-        - pending-id
-        - Type
     Error:
       type: object
       properties:
@@ -1585,6 +1571,9 @@ components:
           enum:
             - file
             - oci-image
+        descriptor:
+          description: Path or image url set when resource is created
+          type: string
     SecretBackend:
       type: object
       properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -431,6 +431,31 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "500":
           $ref: "#/components/responses/InternalServerError"
+  /model/{model}/application/{application}/resources/{resource}:
+    post:
+      tags:
+        - application
+      description: Uploads a resource for an application
+      operationId: addResource
+      parameters:
+        - $ref: "#/components/parameters/Model"
+        - $ref: "#/components/parameters/Application"
+        - $ref: "#/components/parameters/Resource"
+        - $ref: "#/components/parameters/Force"
+        - $ref: "#/components/parameters/DryRun"
+      requestBody:
+        content:
+          application/octet-stream: {}
+        required: true
+      responses:
+        "200":
+          $ref: "#/components/responses/EntityCreated"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
   /model/{model}/credential:
     patch:
       tags:
@@ -1760,6 +1785,13 @@ components:
       name: model
       required: true
       description: The name of a model in the controller.
+      schema:
+        type: string
+    Resource:
+      in: path
+      name: resource
+      required: true
+      description: The name of a resource for an application.
       schema:
         type: string
     Scale:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -834,6 +834,7 @@ components:
         id:
           type: string
         instance-key:
+          description: A unique string associated with the application. Create with the charmhub.CreateInstanceKey method.
           type: string
         revision:
           type: integer

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -745,15 +745,25 @@ components:
           $ref: '#/components/schemas/CharmOrigin'
         charm-url:
           type: string
+        config-settings:
+          type: object
+          additionalProperties:
+            type: string
+        config-settings-yaml:
+          type: string
+        resource-ids:
+          type: object
+          additionalProperties:
+            type: string
+        storage-constraints:
+          type: object
+          additionalProperties:
+            type: '#/components/schemas/StorageConstraints'
       additionalProperties: false
       required:
         - application
-        - generation
         - charm-url
-        - channel
-        - force
-        - force-units
-        - force-base
+        - charm-origin
     Architecture:
       type: string
       enum:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -44,6 +44,11 @@ tags:
     externalDocs:
       description: Find out more about Juju clouds.
       url: https://juju.is/docs/olm/manage-clouds
+  - name: user
+    description: Manage Juju users
+    externalDocs:
+      description: Find out more about Juju users.
+      url: https://juju.is/docs/olm/manage-users
 paths:
   /cloud/{name}:
     get:
@@ -463,6 +468,93 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/EmptySyncResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  
+  /user/{name}:
+    get:
+      tags:
+        - user
+      summary: Returns information about a specific user.
+      description: |
+        Returns information about a specific user.
+      operationId: getUser
+      parameters:
+        - $ref: "#/components/parameters/User"
+      responses:
+        "200":
+          $ref: '#/components/schemas/User'
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+    patch:
+      tags:
+        - user
+      summary: Updates a user.
+      description: |
+        Updates a given user including display-name, enabled/disabled state and password.
+      operationId: updateUser
+      parameters:
+        - $ref: "#/components/parameters/User"
+      requestBody:
+        description: User creation parameters.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UserArgs"
+        required: true
+      responses:
+        "200":
+          $ref: "#/components/responses/EmptySyncResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+    delete:
+      tags:
+        - user
+      summary: Delete a user.
+      description: |
+        Permanently removes a user from the current controller. While the user is permanently
+        removed we keep it's information around for auditing purposes.
+      operationId: deleteUser
+      parameters:
+        - $ref: "#/components/parameters/User"
+      responses:
+        "200":
+          $ref: "#/components/responses/EmptySyncResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /users:
+    post:
+      tags:
+        - user
+      summary: Adds a new user.
+      description: Adds a new user to the controller.
+      operationId: addUser
+      requestBody:
+        description: User creation parameters.
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UserArgs"
+        required: true
+      responses:
+        "200":
+          $ref: "#/components/responses/EntityCreated"
         "400":
           $ref: "#/components/responses/BadRequest"
         "403":
@@ -1099,6 +1191,54 @@ components:
         - Tag
         - Patch
         - Build
+    User:
+      type: object
+      properties:
+        display-name:
+          type: string
+        username:
+          type: string
+        enabled:
+          type: boolean
+          default: true
+        access:
+          description: Level of access granted to the specified user.
+          type: string
+          enum:
+            - login
+            - superuser
+        createdBy:
+          type: string
+          description: Identifier of user that created this user
+        createdAt:
+          type: string
+          format: date-time
+        lastConnection:
+          type: string
+          format: date-time
+      additionalProperties: false
+      required:
+        - display-name
+        - username
+        - enabled
+        - access
+    UserArgs:
+      type: object
+      properties:
+        display-name:
+          type: string
+        username:
+          type: string
+        enabled:
+          type: boolean
+          default: true
+        password:
+          type: string
+      additionalProperties: false
+      required:
+        - display-name
+        - username
+        - password
   parameters:
     All:
       in: query

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1052,13 +1052,13 @@ components:
           type: string
         application-name:
           type: string
-        attachStorage:
+        attach-storage:
           type: array
           items:
             type: string
-        charmName:
+        charm-name:
           type: string
-        configYAML:
+        config-yaml:
           type: string
         constraints:
           $ref: '#/components/schemas/Constraints'
@@ -1090,7 +1090,7 @@ components:
           type: integer
       additionalProperties: false
       required:
-        - charmName
+        - charm-name
     PendingResourceUpload:
       type: object
       description: Information about the local resources that need to be uploaded by the client after a deploy operation.
@@ -1115,7 +1115,7 @@ components:
         error:
           type: string
           example: Bad request.
-        error_code:
+        error-code:
           type: integer
           example: 400
         type:
@@ -1674,13 +1674,13 @@ components:
           enum:
             - login
             - superuser
-        createdBy:
+        created-by:
           type: string
           description: Identifier of user that created this user
-        createdAt:
+        created-at:
           type: string
           format: date-time
-        lastConnection:
+        last-connection:
           type: string
           format: date-time
       additionalProperties: false
@@ -1744,21 +1744,15 @@ components:
       description: Return detailed information about requested entity.
       required: false
       schema:
-        type: string
-        default: "false"
-        enum:
-          - "true"
-          - "false"
+        type: boolean
+        default: false
     DryRun:
       in: query
       name: dry-run
       required: false
       schema:
         type: boolean
-        default: "false"
-        enum:
-          - "true"
-          - "false"
+        default: false
     Force:
       in: query
       name: force

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1615,12 +1615,14 @@ components:
       required: false
       schema:
         type: boolean
+        default: false
     Force:
       in: query
       name: force
       required: false
       schema:
         type: boolean
+        default: false
     MaxWait:
       in: query
       name: max-wait
@@ -1652,6 +1654,7 @@ components:
       required: false
       schema:
         type: boolean
+        default: false
     User:
       in: query
       name: user

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -704,8 +704,15 @@ components:
           type: boolean
         role:
           type: string
+          enum:
+            - provider
+            - requirer
+            - peer
         scope:
           type: string
+          enum:
+            - global
+            - container
       additionalProperties: false
       required:
         - name

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -923,7 +923,7 @@ components:
       properties:
         allocate-public-ip:
           type: boolean
-        arch:
+        architecture:
           type: string
         container:
           type: string
@@ -1071,7 +1071,7 @@ components:
     MachineHardware:
       type: object
       properties:
-        arch:
+        architecture:
           type: string
         availability-zone:
           type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -59,10 +59,16 @@ paths:
     post:
       tags:
         - application
-      description: Deploy an application. If a local resource is provided, details
-        required for uploading the validated resource will be returned.
-      # This needs to return info about local resources to be uploaded by the client
-      # post-deploy (PendingResourceUpload)
+      description: |
+        Deploy an application. 
+
+        Returns a simple response with a location header pointing to the deployed
+        application.
+
+        If the deployment relies upon local resources being uploaded, clients should
+        retrieve the URL in the location header send in the response in order to
+        learn the URL resources should be POSTed too after deploy (see `uploadResource`
+        operation).
       operationId: addApplication
       parameters:
         - $ref: "#/components/parameters/Force"
@@ -436,7 +442,7 @@ paths:
       tags:
         - application
       description: Uploads a resource for an application
-      operationId: addResource
+      operationId: uploadResource
       parameters:
         - $ref: "#/components/parameters/Model"
         - $ref: "#/components/parameters/Application"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -617,7 +617,7 @@ components:
         base:
           $ref: '#/components/schemas/Base'
         channel:
-          type: string
+          $ref: '#/components/schemas/CharmChannel'
         charm:
           type: string
         constraints:
@@ -703,6 +703,7 @@ components:
       type: object
       properties:
         channel:
+          # TODO: BaseChannel object
           type: string
         name:
           type: string
@@ -710,6 +711,20 @@ components:
       required:
         - name
         - channel
+    CharmChannel:
+      type: object
+      properties:
+        track:
+          type: string
+        risk:
+          type: string
+          enum:
+            - stable
+            - candidate
+            - beta
+            - edge
+        branch:
+          type: string
     CharmIntegration:
       type: object
       properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1571,12 +1571,17 @@ components:
       allOf:
         - $ref: "#/components/schemas/ModelStorageAttributes"
     Placement:
+      description: Defines a placement directive, which has a scope and a value that is scope-specific.
       type: object
       properties:
         directive:
+          description: Scope-specific placement directive.
           type: string
         scope:
-          type: string
+          description: Can be a container type or a machine scope (#).
+          oneOf:
+            - $ref: '#/components/schemas/ContainerType'
+            - const: "#"
       additionalProperties: false
       required:
         - scope

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -602,7 +602,6 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  
   /user/{user}:
     get:
       tags:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -742,7 +742,7 @@ components:
           type: string
         charm-origin:
           $ref: '#/components/schemas/CharmOrigin'
-        charm-url:
+        charm-name:
           type: string
         config-settings:
           type: object
@@ -761,8 +761,7 @@ components:
       additionalProperties: false
       required:
         - application
-        - charm-url
-        - charm-origin
+        - charm-name
     Architecture:
       type: string
       enum:
@@ -1091,6 +1090,7 @@ components:
       additionalProperties: false
       required:
         - charm-name
+        - model
     PendingResourceUpload:
       type: object
       description: Information about the local resources that need to be uploaded by the client after a deploy operation.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -50,77 +50,7 @@ tags:
       description: Find out more about Juju clouds.
       url: https://juju.is/docs/olm/manage-clouds
 paths:
-  /application/{name}:
-    get:
-      tags:
-        - application
-      description: Returns application information.
-      operationId: getApplication
-      parameters:
-        - $ref: "#/components/parameters/ApplicationName"
-      responses:
-        "200":
-          description: Detailed information about the requested application.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Application"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "403":
-          $ref: "#/components/responses/Forbidden"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-    post:
-      tags:
-        - application
-      description: Is a one-stop deployment method for repository charms. Only a charm
-        name is required to deploy. If argument validation fails, a list of all errors
-        found in validation will be returned. If a local resource is provided, details
-        required for uploading the validated resource will be returned.
-      operationId: addApplication
-      parameters:
-        - $ref: "#/components/parameters/ApplicationName"
-        - $ref: "#/components/parameters/Force"
-        - $ref: "#/components/parameters/DryRun"
-        - $ref: "#/components/parameters/Trust"
-        - $ref: "#/components/parameters/Scale"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DeployArgs'
-        required: true
-      responses:
-        "200":
-          $ref: "#/components/responses/EntityCreated"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "403":
-          $ref: "#/components/responses/Forbidden"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-    delete:
-      tags:
-        - application
-      description: Removes a given application.
-      operationId: deleteApplication
-      parameters:
-        - $ref: "#/components/parameters/ApplicationName"
-        - $ref: "#/components/parameters/DestroyStorage"
-        - $ref: "#/components/parameters/Force"
-        - $ref: "#/components/parameters/MaxWait"
-        - $ref: "#/components/parameters/DryRun"
-      responses:
-        "200":
-          $ref: "#/components/responses/EmptySyncResponse"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "403":
-          $ref: "#/components/responses/Forbidden"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-  /application/{name}/refresh:
+  /application/{app-name}/refresh:
     patch:
       tags:
         - application
@@ -143,7 +73,7 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /integrate
+  /integrate:
     post:
       tags:
         - application
@@ -166,7 +96,7 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /cloud/{name}:
+  /cloud/{cloud-name}:
     get:
       tags:
         - cloud
@@ -208,7 +138,7 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /cloud/{name}/access:
+  /cloud/{cloud-name}/access:
     get:
       tags:
         - cloud
@@ -327,7 +257,7 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /model/{name}:
+  /model/{model-name}:
     get:
       tags:
         - model
@@ -372,7 +302,7 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /model/{name}/access:
+  /model/{model-name}/access:
     get:
       tags:
         - model
@@ -421,7 +351,79 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /model/{name}/credential:
+  /model{model-name}/application/{app-name}:
+    get:
+      tags:
+        - application
+      description: Returns application information.
+      operationId: getApplication
+      parameters:
+        - $ref: "#/components/parameters/ModelName"
+        - $ref: "#/components/parameters/ApplicationName"
+      responses:
+        "200":
+          description: Detailed information about the requested application.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Application"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+    post:
+      tags:
+        - application
+      description: Is a one-stop deployment method for repository charms. Only a charm
+        name is required to deploy. If argument validation fails, a list of all errors
+        found in validation will be returned. If a local resource is provided, details
+        required for uploading the validated resource will be returned.
+      operationId: addApplication
+      parameters:
+        - $ref: "#/components/parameters/ApplicationName"
+        - $ref: "#/components/parameters/Force"
+        - $ref: "#/components/parameters/DryRun"
+        - $ref: "#/components/parameters/Trust"
+        - $ref: "#/components/parameters/Scale"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeployArgs'
+        required: true
+      responses:
+        "200":
+          $ref: "#/components/responses/EntityCreated"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+    delete:
+      tags:
+        - application
+      description: Removes a given application.
+      operationId: deleteApplication
+      parameters:
+        - $ref: "#/components/parameters/ModelName"
+        - $ref: "#/components/parameters/ApplicationName"
+        - $ref: "#/components/parameters/DestroyStorage"
+        - $ref: "#/components/parameters/Force"
+        - $ref: "#/components/parameters/MaxWait"
+        - $ref: "#/components/parameters/DryRun"
+      responses:
+        "200":
+          $ref: "#/components/responses/EmptySyncResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /model/{model-name}/credential:
     patch:
       tags:
         - model
@@ -447,7 +449,7 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /model/{name}/status:
+  /model/{model-name}/status:
     get:
       tags:
         - model
@@ -1568,14 +1570,14 @@ components:
           - false
     ApplicationName:
       in: path
-      name: name
+      name: app-name
       required: true
       description: The name of a deployed application.
       schema:
         type: string
     CloudName:
       in: path
-      name: name
+      name: cloud-name
       required: true
       description: The name of a cloud in the controller.
       schema:
@@ -1622,7 +1624,7 @@ components:
         type: integer
     ModelName:
       in: path
-      name: name
+      name: model-name
       required: true
       description: The name of a model in the controller.
       schema:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -373,13 +373,35 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "500":
           $ref: "#/components/responses/InternalServerError"
+    delete:
+      tags:
+        - application
+      description: Removes a given application.
+      operationId: deleteApplication
+      parameters:
+        - $ref: "#/components/parameters/ModelName"
+        - $ref: "#/components/parameters/ApplicationName"
+        - $ref: "#/components/parameters/DestroyStorage"
+        - $ref: "#/components/parameters/Force"
+        - $ref: "#/components/parameters/MaxWait"
+        - $ref: "#/components/parameters/DryRun"
+      responses:
+        "200":
+          $ref: "#/components/responses/EmptySyncResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /model{model-name}/application/{app-name}/deploy:
     post:
       tags:
         - application
-      description: Is a one-stop deployment method for repository charms. Only a charm
-        name is required to deploy. If argument validation fails, a list of all errors
-        found in validation will be returned. If a local resource is provided, details
+      description: Deploy an application. If a local resource is provided, details
         required for uploading the validated resource will be returned.
+      # This needs to return info about local resources to be uploaded by the client
+      # post-deploy (PendingResourceUpload)
       operationId: addApplication
       parameters:
         - $ref: "#/components/parameters/ApplicationName"
@@ -396,27 +418,6 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/EntityCreated"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "403":
-          $ref: "#/components/responses/Forbidden"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-    delete:
-      tags:
-        - application
-      description: Removes a given application.
-      operationId: deleteApplication
-      parameters:
-        - $ref: "#/components/parameters/ModelName"
-        - $ref: "#/components/parameters/ApplicationName"
-        - $ref: "#/components/parameters/DestroyStorage"
-        - $ref: "#/components/parameters/Force"
-        - $ref: "#/components/parameters/MaxWait"
-        - $ref: "#/components/parameters/DryRun"
-      responses:
-        "200":
-          $ref: "#/components/responses/EmptySyncResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
         "403":

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -55,6 +55,35 @@ tags:
       description: Find out more about Juju users.
       url: https://juju.is/docs/olm/manage-users
 paths:
+  /deploy:
+    post:
+      tags:
+        - application
+      description: Deploy an application. If a local resource is provided, details
+        required for uploading the validated resource will be returned.
+      # This needs to return info about local resources to be uploaded by the client
+      # post-deploy (PendingResourceUpload)
+      operationId: addApplication
+      parameters:
+        - $ref: "#/components/parameters/Force"
+        - $ref: "#/components/parameters/DryRun"
+        - $ref: "#/components/parameters/Trust"
+        - $ref: "#/components/parameters/Scale"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DeployArgs'
+        required: true
+      responses:
+        "200":
+          $ref: "#/components/responses/EntityCreated"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
   /integrate:
     post:
       tags:
@@ -370,37 +399,6 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/EmptySyncResponse"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "403":
-          $ref: "#/components/responses/Forbidden"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
-  /model{model}/application/{application}/deploy:
-    post:
-      tags:
-        - application
-      description: Deploy an application. If a local resource is provided, details
-        required for uploading the validated resource will be returned.
-      # This needs to return info about local resources to be uploaded by the client
-      # post-deploy (PendingResourceUpload)
-      operationId: addApplication
-      parameters:
-        - $ref: "#/components/parameters/Application"
-        - $ref: "#/components/parameters/Model"
-        - $ref: "#/components/parameters/Force"
-        - $ref: "#/components/parameters/DryRun"
-        - $ref: "#/components/parameters/Trust"
-        - $ref: "#/components/parameters/Scale"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/DeployArgs'
-        required: true
-      responses:
-        "200":
-          $ref: "#/components/responses/EntityCreated"
         "400":
           $ref: "#/components/responses/BadRequest"
         "403":
@@ -758,7 +756,7 @@ components:
         storage-constraints:
           type: object
           additionalProperties:
-            type: '#/components/schemas/StorageConstraints'
+            $ref: '#/components/schemas/StorageConstraints'
       additionalProperties: false
       required:
         - application
@@ -1050,6 +1048,10 @@ components:
     DeployArgs:
       type: object
       properties:
+        model-name:
+          type: string
+        application-name:
+          type: string
         attachStorage:
           type: array
           items:
@@ -1075,7 +1077,7 @@ components:
         base:
           $ref: '#/components/schemas/Base'
         channel:
-          type: string
+          $ref: '#/components/schemas/CharmChannel'
         endpoint-bindings:
           type: object
           additionalProperties:
@@ -1088,7 +1090,7 @@ components:
           type: integer
       additionalProperties: false
       required:
-        - CharmName
+        - charmName
     PendingResourceUpload:
       type: object
       description: Information about the local resources that need to be uploaded by the client after a deploy operation.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -727,9 +727,9 @@ components:
       type: object
       properties:
         provider:
-          $ref: '#/components/schemas/Intergrator'
+          $ref: '#/components/schemas/Integrator'
         requirer:
-          $ref: '#/components/schemas/Intergrator'
+          $ref: '#/components/schemas/Integrator'
       additionalProperties: false
       required:
         - provider
@@ -1143,7 +1143,7 @@ components:
         - error
         - error_code
         - type
-    Intergrator:
+    Integrator:
       description: An entity describing one end of an integration.
       type: object
       properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -713,10 +713,6 @@ components:
       type: object
       description: Information about a given application.
       properties:
-        base:
-          $ref: '#/components/schemas/Base'
-        channel:
-          $ref: '#/components/schemas/CharmChannel'
         charm-origin:
           $ref: '#/components/schemas/CharmOrigin'
         charm:
@@ -832,8 +828,8 @@ components:
           $ref: '#/components/schemas/Architecture'
         base:
           $ref: '#/components/schemas/Base'
-        branch:
-          type: string
+        channel:
+          $ref: '#/components/schemas/CharmChannel'
         hash:
           type: string
         id:
@@ -842,15 +838,11 @@ components:
           type: string
         revision:
           type: integer
-        risk:
-          type: string
         source:
           type: string
           enum:
             - local
             - charm-hub
-        track:
-          type: string
         type:
           type: string
           enum:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -749,10 +749,10 @@ components:
             type: string
         config-settings-yaml:
           type: string
-        resource-ids:
-          type: object
-          additionalProperties:
-            type: string
+        resources:
+          type: array
+          items:
+            $ref: '#/components/schemas/Resource'
         storage-constraints:
           type: object
           additionalProperties:
@@ -1560,6 +1560,18 @@ components:
       required:
         - region-name
         - value
+    Resource:
+      type: object
+      properties:
+        name:
+          type: string
+        id:
+          type: string
+        type:
+          type: string
+          enum:
+            - file
+            - oci-image
     SecretBackend:
       type: object
       properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -411,7 +411,7 @@ paths:
     patch:
       tags:
         - application
-      description: Sets the charm for a given for the application.
+      description: Resets the charm for a given for the application.
       operationId: refreshApplication
       parameters:
         - $ref: "#/components/parameters/Model"
@@ -740,8 +740,6 @@ components:
       type: object
       properties:
         application:
-          type: string
-        channel:
           type: string
         charm-origin:
           $ref: '#/components/schemas/CharmOrigin'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1010,45 +1010,66 @@ components:
       required:
         - permissions
     Constraints:
+      description: Describes a user's requirements of the hardware on which units of an application will run. Constraints are used to choose an existing machine onto which a unit will be deployed, or to provision a new machine if no existing one satisfies the requirements.
       type: object
       properties:
         allocate-public-ip:
           type: boolean
         architecture:
+          description: Indicates that a machine must run the named architecture.
           $ref: '#/components/schemas/Architecture'
         container:
-          type: string
+          description: Indicates that a machine must be the specified container type.
+          $ref: '#/components/schemas/ContainerType'
         cores:
+          description: Indicates that a machine must have at least that number of effective cores available.
           type: integer
         cpu-power:
+          description: Indicates that a machine must have at least that amount of CPU power available, where 100 CpuPower is considered to be equivalent to 1 Amazon ECU (or, roughly, a single 2007-era Xeon).
           type: integer
         image-id:
+          description: Indicates that a machine must use the specified image. This is provider specific, and for the moment is only implemented on MAAS clouds.
           type: string
         instance-role:
+          description: Indicates that the specified role/profile for the given cloud should be used. Only valid for clouds which support instance roles. Currently only for AWS with instance-profiles.
           type: string
         instance-type:
+          description: Indicates that the specified cloud instance type be used. Only valid for clouds which support instance types.
           type: string
         mem:
+          description: Indicates that a machine must have at least that many megabytes of RAM.
           type: integer
         root-disk:
+          description: Indicates that a machine must have at least that many megabytes of disk space available in the root disk.
           type: integer
         root-disk-source:
+          description: Determines what storage the root disk should be allocated from. This will be provider specific - in the case of vSphere it identifies the datastore the root disk file should be created in.
           type: string
         spaces:
+          description: Holds a list of juju network spaces that should be available (or not) on the machine. Positive and negative values are accepted, and the difference is the latter have a "^" prefix to the name.
           type: array
           items:
             type: string
         tags:
+          description: Indicates tags that the machine must have applied to it.
           type: array
           items:
             type: string
         virt-type:
+          description: Indicates that a machine must run the named virtual type. Only valid for clouds with multi-hypervisor support.
           type: string
         zones:
+          description: Holds a list of availability zones limiting where the machine can be located.
           type: array
           items:
             type: string
       additionalProperties: false
+    ContainerType:
+      type: string
+      enum:
+        - none
+        - lxd
+        - kvm
     DeployArgs:
       type: object
       properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -695,17 +695,14 @@ components:
     IntegrateArgs:
       type: object
       properties:
-        endpoints:
-          type: array
-          items:
-            type: string
-        via-cidrs:
-          type: array
-          items:
-            type: string
+        provider:
+          $ref: '#/components/schemas/Intergrator'
+        requirer:
+          $ref: '#/components/schemas/Intergrator'
       additionalProperties: false
       required:
-        - endpoints
+        - provider
+        - requirer
     Application:
       type: object
       description: Information about a given application.
@@ -1126,6 +1123,19 @@ components:
         - error
         - error_code
         - type
+    Intergrator:
+      description: An entity describing one end of an integration.
+      type: object
+      properties:
+        model:
+          type: string
+        application:
+          type: string
+        endpoint:
+          type: string
+      required:
+        - model
+        - application
     ExposedEndpoint:
       type: object
       properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -831,6 +831,7 @@ components:
         channel:
           $ref: '#/components/schemas/CharmChannel'
         hash:
+          description: The hash of the charm in CharmHub located by this origin.
           type: string
         id:
           type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1045,7 +1045,7 @@ components:
     DeployArgs:
       type: object
       properties:
-        model-name:
+        model:
           type: string
         application-name:
           type: string
@@ -1751,7 +1751,7 @@ components:
       name: dry-run
       required: false
       schema:
-        type: string
+        type: boolean
         default: "false"
         enum:
           - "true"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -957,26 +957,26 @@ components:
     DeployArgs:
       type: object
       properties:
-        AttachStorage:
+        attachStorage:
           type: array
           items:
             type: string
-        CharmName:
+        charmName:
           type: string
-        ConfigYAML:
+        configYAML:
           type: string
-        Cons:
+        constraints:
           $ref: '#/components/schemas/Constraints'
-        Devices:
+        devices:
           type: object
           patternProperties:
             .*:
               $ref: '#/components/schemas/Constraints'
-        Placement:
+        placement:
           type: array
           items:
             $ref: '#/components/schemas/Placement'
-        Storage:
+        storage:
           type: object
           patternProperties:
             .*:
@@ -1021,11 +1021,11 @@ components:
       type: object
       description: Information about the local resources that need to be uploaded by the client after a deploy operation.
       properties:
-        Filename:
+        filename:
           type: string
-        Name:
+        name:
           type: string
-        Type:
+        type:
           type: string
         pending-id:
           type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -155,7 +155,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/UserCloudList"
+                $ref: "#/components/schemas/CloudList"
         "400":
           $ref: "#/components/responses/BadRequest"
         "403":
@@ -366,7 +366,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/UserModelList"
+                $ref: "#/components/schemas/ModelList"
         "400":
           $ref: "#/components/responses/BadRequest"
         "403":

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -737,7 +737,6 @@ components:
         - principal
         - exposed
         - remote
-        - life
     ApplicationSubstitute:
       type: object
       properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -665,6 +665,13 @@ components:
         - force
         - force-units
         - force-base
+    Architecture:
+      type: string
+      enum:
+        - amd64
+        - arm64
+        - i386
+        - riscv64
     Base:
       type: object
       properties:
@@ -725,7 +732,7 @@ components:
       type: object
       properties:
         architecture:
-          type: string
+          $ref: '#/components/schemas/Architecture'
         base:
           $ref: '#/components/schemas/Base'
         branch:
@@ -912,7 +919,7 @@ components:
         allocate-public-ip:
           type: boolean
         architecture:
-          type: string
+          $ref: '#/components/schemas/Architecture'
         container:
           type: string
         cores:
@@ -992,7 +999,7 @@ components:
       type: object
       properties:
         architecture:
-          type: string
+          $ref: '#/components/schemas/Architecture'
         base:
           $ref: '#/components/schemas/Base'
         channel:
@@ -1056,7 +1063,7 @@ components:
       type: object
       properties:
         architecture:
-          type: string
+          $ref: '#/components/schemas/Architecture'
         availability-zone:
           type: string
         cores:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -749,10 +749,16 @@ components:
           type: string
         source:
           type: string
+          enum:
+            - local
+            - charm-hub
         track:
           type: string
         type:
           type: string
+          enum:
+            - charm
+            - bundle
       additionalProperties: false
       required:
         - source

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -797,36 +797,6 @@ components:
             - edge
         branch:
           type: string
-    CharmIntegration:
-      type: object
-      properties:
-        interface:
-          type: string
-        limit:
-          type: integer
-        name:
-          type: string
-        optional:
-          type: boolean
-        role:
-          type: string
-          enum:
-            - provider
-            - requirer
-            - peer
-        scope:
-          type: string
-          enum:
-            - global
-            - container
-      additionalProperties: false
-      required:
-        - name
-        - role
-        - interface
-        - optional
-        - limit
-        - scope
     CharmOrigin:
       type: object
       properties:
@@ -1119,23 +1089,6 @@ components:
       additionalProperties: false
       required:
         - CharmName
-    DeployFromRepositoryInfo:
-      type: object
-      properties:
-        architecture:
-          $ref: '#/components/schemas/Architecture'
-        base:
-          $ref: '#/components/schemas/Base'
-        channel:
-          type: string
-        charm-url:
-          type: string
-        effective-channel:
-          type: string
-      additionalProperties: false
-      required:
-        - charm-url
-        - architecture
     PendingResourceUpload:
       type: object
       description: Information about the local resources that need to be uploaded by the client after a deploy operation.
@@ -1869,12 +1822,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
-    IntegrationCreated:
-      description: Integration added between specified endpoints.
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/CharmIntegration'
 # Use this section to define reusable objects
 # callbacks: {}
 # examples: {}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -60,7 +60,7 @@ paths:
       tags:
         - application
       description: |
-        Deploy an application. 
+        Deploy an application.
 
         Returns a simple response with a location header pointing to the deployed
         application.
@@ -95,8 +95,7 @@ paths:
       tags:
         - application
       summary: Adds a relation.
-      description: Adds a relation between the specified endpoints and returns the
-        relation info.
+      description: Adds a relation between the specified endpoints and returns the relation info.
       operationId: relateApplication
       requestBody:
         content:
@@ -118,8 +117,7 @@ paths:
       tags:
         - cloud
       summary: Get a specific cloud.
-      description: |
-        Returns detailed information about a given cloud
+      description: Returns detailed information about a given cloud.
       operationId: getCloud
       parameters:
         - $ref: "#/components/parameters/Cloud"
@@ -183,8 +181,7 @@ paths:
       tags:
         - cloud
       summary: Change the cloud access granted to users.
-      description: |
-        Update the level of cloud access that is granted to specific users.
+      description: Update the level of cloud access that is granted to specific users.
       operationId: updateCloudUserAccess
       parameters:
         - $ref: "#/components/parameters/Cloud"
@@ -279,8 +276,7 @@ paths:
       tags:
         - model
       summary: Get a specific model.
-      description: |
-        Returns detailed information about a given model
+      description: Returns detailed information about a given model.
       operationId: getModel
       parameters:
         - $ref: "#/components/parameters/Model"
@@ -301,8 +297,7 @@ paths:
       tags:
         - model
       summary: Delete a model.
-      description: |
-        Delete a model from the controller.
+      description: Delete a model from the controller.
       operationId: deleteModel
       parameters:
         - $ref: "#/components/parameters/Model"
@@ -332,7 +327,7 @@ paths:
         - $ref: "#/components/parameters/Model"
       responses:
         "200":
-          description: List of model access controls
+          description: List of model access controls.
           content:
             application/json:
               schema:
@@ -441,7 +436,7 @@ paths:
     post:
       tags:
         - application
-      description: Uploads a resource for an application
+      description: Uploads a resource for an application.
       operationId: uploadResource
       parameters:
         - $ref: "#/components/parameters/Model"
@@ -516,7 +511,12 @@ paths:
       tags:
         - model
       summary: List models
-      description: "Returns the models that the specified user has access to in the current server.\n\nController admins (superuser) can list models for any user. \n\nOther users can only ask about their own models.\n"
+      description: |
+        Returns the models that the specified user has access to in the current server.
+
+        Controller admins (superuser) can list models for any user.
+
+        Other users can only ask about their own models.
       operationId: listModels
       parameters:
         - $ref: "#/components/parameters/All"
@@ -562,8 +562,7 @@ paths:
       tags:
         - model
       summary: List model defaults.
-      description: |
-        Returns the model defaults for the specified clouds.
+      description: Returns the model defaults for the specified clouds.
       operationId: listModelDefaults
       parameters:
         - name: clouds
@@ -844,7 +843,10 @@ components:
         id:
           type: string
         instance-key:
-          description: A unique string associated with the application. Create with the charmhub.CreateInstanceKey method.
+          description: |
+            A unique string associated with the application.
+
+            Create with the charmhub.CreateInstanceKey method.
           type: string
         revision:
           type: integer
@@ -1019,7 +1021,11 @@ components:
       required:
         - permissions
     Constraints:
-      description: Describes a user's requirements of the hardware on which units of an application will run. Constraints are used to choose an existing machine onto which a unit will be deployed, or to provision a new machine if no existing one satisfies the requirements.
+      description: |
+        Describes a user's requirements of the hardware on which units of an application will run.
+
+        Constraints are used to choose an existing machine onto which a unit will be deployed,
+        or to provision a new machine if no existing one satisfies the requirements.
       type: object
       properties:
         allocate-public-ip:
@@ -1034,16 +1040,27 @@ components:
           description: Indicates that a machine must have at least that number of effective cores available.
           type: integer
         cpu-power:
-          description: Indicates that a machine must have at least that amount of CPU power available, where 100 CpuPower is considered to be equivalent to 1 Amazon ECU (or, roughly, a single 2007-era Xeon).
+          description: |
+            Indicates that a machine must have at least that amount of CPU power available,
+            where 100 CpuPower is considered to be equivalent to 1 Amazon ECU (or, roughly, a single 2007-era Xeon).
           type: integer
         image-id:
-          description: Indicates that a machine must use the specified image. This is provider specific, and for the moment is only implemented on MAAS clouds.
+          description: |
+            Indicates that a machine must use the specified image.
+
+            This is provider specific, and for the moment is only implemented on MAAS clouds.
           type: string
         instance-role:
-          description: Indicates that the specified role/profile for the given cloud should be used. Only valid for clouds which support instance roles. Currently only for AWS with instance-profiles.
+          description: |
+            Indicates that the specified role/profile for the given cloud should be used.
+
+            Only valid for clouds which support instance roles. Currently only for AWS with instance-profiles.
           type: string
         instance-type:
-          description: Indicates that the specified cloud instance type be used. Only valid for clouds which support instance types.
+          description: |
+            Indicates that the specified cloud instance type be used.
+
+            Only valid for clouds which support instance types.
           type: string
         mem:
           description: Indicates that a machine must have at least that many megabytes of RAM.
@@ -1052,10 +1069,16 @@ components:
           description: Indicates that a machine must have at least that many megabytes of disk space available in the root disk.
           type: integer
         root-disk-source:
-          description: Determines what storage the root disk should be allocated from. This will be provider specific - in the case of vSphere it identifies the datastore the root disk file should be created in.
+          description: |
+            Determines what storage the root disk should be allocated from.
+
+            This will be provider specific - in the case of vSphere it identifies the datastore the root disk file should be created in.
           type: string
         spaces:
-          description: Holds a list of juju network spaces that should be available (or not) on the machine. Positive and negative values are accepted, and the difference is the latter have a "^" prefix to the name.
+          description: |
+            Holds a list of juju network spaces that should be available (or not) on the machine.
+
+            Positive and negative values are accepted, and the difference is the latter have a "^" prefix to the name.
           type: array
           items:
             type: string
@@ -1065,7 +1088,10 @@ components:
           items:
             type: string
         virt-type:
-          description: Indicates that a machine must run the named virtual type. Only valid for clouds with multi-hypervisor support.
+          description: |
+            Indicates that a machine must run the named virtual type.
+
+            Only valid for clouds with multi-hypervisor support.
           type: string
         zones:
           description: Holds a list of availability zones limiting where the machine can be located.
@@ -1603,7 +1629,7 @@ components:
             - file
             - oci-image
         descriptor:
-          description: Path or image url set when resource is created
+          description: Path or image url set when resource is created.
           type: string
     SecretBackend:
       type: object
@@ -1696,7 +1722,7 @@ components:
             - superuser
         created-by:
           type: string
-          description: Identifier of user that created this user
+          description: Identifier of user that created this user.
         created-at:
           type: string
           format: date-time
@@ -1847,7 +1873,7 @@ components:
           schema:
             $ref: '#/components/schemas/Success'
     EntityCreated:
-      description: Entity created response
+      description: Entity created response.
       content:
         application/json:
           schema:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -624,16 +624,14 @@ components:
           $ref: '#/components/schemas/Constraints'
         endpoint-bindings:
           type: object
-          patternProperties:
-            .*:
-              type: string
+          additionalProperties:
+            type: string
         exposed:
           type: boolean
         exposed-endpoints:
           type: object
-          patternProperties:
-            .*:
-              $ref: '#/components/schemas/ExposedEndpoint'
+          additionalProperties:
+            $ref: '#/components/schemas/ExposedEndpoint'
         life:
           type: string
         principal:
@@ -662,16 +660,14 @@ components:
           type: string
         config-settings:
           type: object
-          patternProperties:
-            .*:
-              type: string
+          additionalProperties:
+            type: string
         config-settings-yaml:
           type: string
         endpoint-bindings:
           type: object
-          patternProperties:
-            .*:
-              type: string
+          additionalProperties:
+            type: string
         force:
           type: boolean
         force-base:
@@ -682,14 +678,12 @@ components:
           type: string
         resource-ids:
           type: object
-          patternProperties:
-            .*:
-              type: string
+          additionalProperties:
+            type: string
         storage-constraints:
           type: object
-          patternProperties:
-            .*:
-              $ref: '#/components/schemas/StorageConstraints'
+          additionalProperties:
+            $ref: '#/components/schemas/StorageConstraints'
       additionalProperties: false
       required:
         - application
@@ -988,32 +982,28 @@ components:
           $ref: '#/components/schemas/Constraints'
         devices:
           type: object
-          patternProperties:
-            .*:
-              $ref: '#/components/schemas/Constraints'
+          additionalProperties:
+            $ref: '#/components/schemas/Constraints'
         placement:
           type: array
           items:
             $ref: '#/components/schemas/Placement'
         storage:
           type: object
-          patternProperties:
-            .*:
-              $ref: '#/components/schemas/Constraints'
+          additionalProperties:
+            $ref: '#/components/schemas/Constraints'
         base:
           $ref: '#/components/schemas/Base'
         channel:
           type: string
         endpoint-bindings:
           type: object
-          patternProperties:
-            .*:
-              type: string
+          additionalProperties:
+            type: string
         resources:
           type: object
-          patternProperties:
-            .*:
-              type: string
+          additionalProperties:
+            type: string
         revision:
           type: integer
       additionalProperties: false

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -34,6 +34,11 @@ externalDocs:
 servers:
   - url: https://localhost:17777/api/v1
 tags:
+  - name: application
+    description: Manage Juju applications
+    externalDocs:
+      description: Find out more about Juju applications.
+      url: https://juju.is/docs/olm/manage-applications
   - name: model
     description: Manage Juju models
     externalDocs:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -93,11 +93,7 @@ paths:
         required: true
       responses:
         "200":
-          description: Detailed information about the requested application.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/DeployFromRepositoryResult"
+          $ref: "#/components/responses/EntityCreated"
         "400":
           $ref: "#/components/responses/BadRequest"
         "403":

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -410,11 +410,13 @@ paths:
       parameters:
         - $ref: "#/components/parameters/ModelName"
         - $ref: "#/components/parameters/ApplicationName"
+        - $ref: "#/components/parameters/Force"
+        - $ref: "#/components/parameters/DryRun"
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ApplicationSetCharm'
+              $ref: '#/components/schemas/ApplicationSubstitute'
         required: true
       responses:
         "200":
@@ -643,7 +645,7 @@ components:
         - exposed
         - remote
         - life
-    ApplicationSetCharm:
+    ApplicationSubstitute:
       type: object
       properties:
         application:
@@ -654,32 +656,6 @@ components:
           $ref: '#/components/schemas/CharmOrigin'
         charm-url:
           type: string
-        config-settings:
-          type: object
-          additionalProperties:
-            type: string
-        config-settings-yaml:
-          type: string
-        endpoint-bindings:
-          type: object
-          additionalProperties:
-            type: string
-        force:
-          type: boolean
-        force-base:
-          type: boolean
-        force-units:
-          type: boolean
-        generation:
-          type: string
-        resource-ids:
-          type: object
-          additionalProperties:
-            type: string
-        storage-constraints:
-          type: object
-          additionalProperties:
-            $ref: '#/components/schemas/StorageConstraints'
       additionalProperties: false
       required:
         - application

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1710,8 +1710,8 @@ components:
         type: string
         default: "false"
         enum:
-          - true
-          - false
+          - "true"
+          - "false"
     Application:
       in: path
       name: application

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -707,10 +707,14 @@ components:
       type: object
       description: Information about a given application.
       properties:
-        charm-origin:
-          $ref: '#/components/schemas/CharmOrigin'
         charm:
           type: string
+        base:
+          $ref: '#/components/schemas/Base'
+        channel:
+          $ref: '#/components/schemas/CharmChannel'
+        revision:
+          type: integer
         constraints:
           $ref: '#/components/schemas/Constraints'
         endpoint-bindings:
@@ -770,7 +774,6 @@ components:
       type: object
       properties:
         channel:
-          # TODO: BaseChannel object
           type: string
         name:
           type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -50,29 +50,6 @@ tags:
       description: Find out more about Juju clouds.
       url: https://juju.is/docs/olm/manage-clouds
 paths:
-  /application/{app-name}/refresh:
-    patch:
-      tags:
-        - application
-      description: Sets the charm for a given for the application.
-      operationId: refreshApplication
-      parameters:
-        - $ref: "#/components/parameters/ApplicationName"
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/ApplicationSetCharm'
-        required: true
-      responses:
-        "200":
-          $ref: "#/components/responses/EmptySyncResponse"
-        "400":
-          $ref: "#/components/responses/BadRequest"
-        "403":
-          $ref: "#/components/responses/Forbidden"
-        "500":
-          $ref: "#/components/responses/InternalServerError"
   /integrate:
     post:
       tags:
@@ -418,6 +395,30 @@ paths:
       responses:
         "200":
           $ref: "#/components/responses/EntityCreated"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "500":
+          $ref: "#/components/responses/InternalServerError"
+  /model/{model-name}/application/{app-name}/refresh:
+    patch:
+      tags:
+        - application
+      description: Sets the charm for a given for the application.
+      operationId: refreshApplication
+      parameters:
+        - $ref: "#/components/parameters/ModelName"
+        - $ref: "#/components/parameters/ApplicationName"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApplicationSetCharm'
+        required: true
+      responses:
+        "200":
+          $ref: "#/components/responses/EmptySyncResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
         "403":

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -79,12 +79,12 @@ paths:
         - $ref: "#/components/parameters/Force"
         - $ref: "#/components/parameters/DryRun"
         - $ref: "#/components/parameters/Trust"
-        - $ref: "#/components/parameters/NumUnits"
+        - $ref: "#/components/parameters/Scale"
       requestBody:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/DeployFromRepositoryArgs'
+              $ref: '#/components/schemas/DeployArgs'
         required: true
       responses:
         "200":
@@ -112,7 +112,7 @@ paths:
         - $ref: "#/components/parameters/DryRun"
       responses:
         "200":
-          $ref: "#/components/responses/ApplicationDestroyed"
+          $ref: "#/components/responses/EmptySyncResponse"
         "400":
           $ref: "#/components/responses/BadRequest"
         "403":
@@ -142,7 +142,7 @@ paths:
           $ref: "#/components/responses/Forbidden"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /application/relate:
+  /integrate
     post:
       tags:
         - application
@@ -154,11 +154,11 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/AddRelationArgs'
+              $ref: '#/components/schemas/IntegrateArgs'
         required: true
       responses:
         "200":
-          $ref: "#/components/responses/RelationCreated"
+          $ref: "#/components/responses/EntityCreated"
         "400":
           $ref: "#/components/responses/BadRequest"
         "403":
@@ -591,7 +591,7 @@ paths:
           $ref: "#/components/responses/InternalServerError"
 components:
   schemas:
-    AddRelationArgs:
+    IntegrateArgs:
       type: object
       properties:
         endpoints:
@@ -705,7 +705,7 @@ components:
       required:
         - name
         - channel
-    CharmRelation:
+    CharmIntegration:
       type: object
       properties:
         interface:
@@ -953,7 +953,7 @@ components:
           items:
             type: string
       additionalProperties: false
-    DeployFromRepositoryArgs:
+    DeployArgs:
       type: object
       properties:
         AttachStorage:
@@ -1016,19 +1016,6 @@ components:
       required:
         - charm-url
         - architecture
-    DeployFromRepositoryResult:
-      type: object
-      properties:
-        Info:
-          $ref: '#/components/schemas/DeployFromRepositoryInfo'
-        PendingResourceUploads:
-          type: array
-          items:
-            $ref: '#/components/schemas/PendingResourceUpload'
-      additionalProperties: false
-      required:
-        - Info
-        - PendingResourceUploads
     PendingResourceUpload:
       type: object
       description: Information about the local resources that need to be uploaded by the client after a deploy operation.
@@ -1614,8 +1601,11 @@ components:
       name: dry-run
       required: false
       schema:
-        type: boolean
+        type: string
         default: false
+        enum:
+          - true
+          - false
     Force:
       in: query
       name: force
@@ -1636,7 +1626,7 @@ components:
       description: The name of a model in the controller.
       schema:
         type: string
-    NumUnits:
+    Scale:
       in: query
       name: num-units
       required: false
@@ -1663,22 +1653,6 @@ components:
       schema:
         type: string
   responses:
-    ApplicationDestroyed:
-      type: object
-      properties:
-        destroyed-storage:
-          type: array
-          items:
-            type: string
-        destroyed-units:
-          type: array
-          items:
-            type: string
-        detached-storage:
-          type: array
-          items:
-            type: string
-      additionalProperties: false
     BadRequest:
       description: Bad request.
       content:
@@ -1715,12 +1689,12 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/Error'
-    RelationCreated:
-      description: Relation added between specified endpoints.
+    IntegrationCreated:
+      description: Integration added between specified endpoints.
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/CharmRelation'
+            $ref: '#/components/schemas/CharmIntegration'
 # Use this section to define reusable objects
 # callbacks: {}
 # examples: {}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -462,8 +462,7 @@ paths:
       tags:
         - model
       summary: Change the credential related to the model.
-      description: |
-        Update the underlying cloud credential that's associated with the model.
+      description: Update the underlying cloud credential that's associated with the model.
       operationId: updateModelCredential
       parameters:
         - $ref: "#/components/parameters/Model"


### PR DESCRIPTION
This adds the following endpoints:

- `getApplication`  - `GET /application/{name}` for `Application.ApplicationsInfo()` 
- `addApplication` - `POST /application/{name}?force=false&dry-run=false&trust=false` for `Application.DeployFromRepository()`
- `deleteApplication` - `DELETE /application/{name}` for `Application.DestroyApplication()`
- `refreshApplication` - `PATCH /application/{name}` for `Application.SetCharm()`
- `relateApplication` - `POST /application/relate` for `Application.AddRelation()`

#### Some notes
- Some custom responses are added, e.g., `ApplicationDestroyed`, `RelationCreated`, etc.
- Some schema types are renamed (not the existing ones, but the ones coming from the juju facades), e.g., `ApplicationResult -> Application`, not sure if I should document all the renames.
- Reviewer be advised, I just learned about the openAPI spec this afternoon and this is literally the first time I'm writing one, so there's probably some errors in there.