### PR TITLE
Add/Remove some endpoints.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ This table tracks progress through the redesign of the Juju client API:
 | Application          | DestroyUnit                     |                                                          |
 | Application          | Expose                          |                                                          |
 | Application          | Get                             |                                                          |
-| Application          | GetCharmURLOrigin               |                                                          |
 | Application          | GetConfig                       |                                                          |
 | Application          | GetConstraints                  |                                                          |
 | Application          | Leader                          |                                                          |
@@ -116,7 +115,6 @@ This table tracks progress through the redesign of the Juju client API:
 | Bundle               | GetChanges                      |                                                          |
 | Bundle               | GetChangesMapArgs               |                                                          |
 | Charms               | AddCharm                        |                                                          |
-| Charms               | CharmInfo                       |                                                          |
 | Charms               | CheckCharmPlacement             |                                                          |
 | Charms               | GetDownloadInfos                |                                                          |
 | Charms               | IsMetered                       |                                                          |
@@ -220,10 +218,8 @@ This table tracks progress through the redesign of the Juju client API:
 | ModelManager         | UnsetModelDefaults              | `PATCH /models/defaults`                                 |
 | ModelUpgrader        | AbortModelUpgrade               |                                                          |
 | ModelUpgrader        | UpgradeModel                    |                                                          |
-| Payloads             | List                            |                                                          |
-| Pinger               | Ping                            |                                                          |
-| Pinger               | Stop                            |                                                          |
 | Resources            | AddPendingResources             |                                                          |
+| Resources            | Attach                          |                                                          |
 | Resources            | ListResources                   |                                                          |
 | SSHClient            | AllAddresses                    |                                                          |
 | SSHClient            | ModelCredentialForSSH           |                                                          |


### PR DESCRIPTION
GetCharmURLOrigin is removed. An implementation detail necessary for application deploy and refresh with the juju 3.x clients. Should not be need in the new api definition.

Added Resource Attach to mimic the `juju attach-resource` command.

Removed Payload List, Pinger Ping, and Pinger Stop. They are used by juju agents and not the actual juju client.

Updated the controller config functionality with API paths.